### PR TITLE
feat(web): improve job detail card with unified facts grid

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -293,8 +293,12 @@ body {
 .detail-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem 1.25rem;
-  margin-bottom: 1.25rem;
+  gap: 0.9rem 1.25rem;
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.1rem;
+  background: #f8fafc;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
 }
 
 .detail-loading,
@@ -312,6 +316,8 @@ body {
   font-size: 0.75rem;
   color: #94a3b8;
   margin-top: 1rem;
+  text-align: right;
+  font-style: italic;
 }
 
 .sync-button {
@@ -524,6 +530,15 @@ body {
   font-size: 1rem;
   color: var(--text-muted);
   font-weight: 500;
+}
+
+.job-department {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--primary);
 }
 
 .job-details-body {

--- a/web/src/components/JobDetails.jsx
+++ b/web/src/components/JobDetails.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import DOMPurify from 'dompurify';
 import JsonTree from './JsonTree';
 import { formatWorkplaceType, formatJobType } from '../utils/formatters';
+import { extractCommonFacts, formatRelative } from '../utils/detailFields';
 
 function pickRawJson(detail) {
   if (!detail) return null;
@@ -26,35 +27,38 @@ function renderTextBlock(text) {
   return <div className="detail-text">{text}</div>;
 }
 
+function sourceBlocks(detail) {
+  if (detail.source === 'gupy') {
+    return [
+      ['Descrição', renderHtmlBlock(detail.description_html)],
+      ['Responsabilidades', renderHtmlBlock(detail.responsibilities_html)],
+      ['Pré-requisitos', renderHtmlBlock(detail.prerequisites_html)],
+    ];
+  }
+  if (detail.source === 'inhire') {
+    return [
+      ['Descrição', renderHtmlBlock(detail.description_html)],
+      ['Sobre a empresa', renderHtmlBlock(detail.about_html)],
+    ];
+  }
+  if (detail.source === 'linkedin') {
+    return [['Descrição', renderTextBlock(detail.description)]];
+  }
+  return [];
+}
+
 function SourceDetail({ detail }) {
   if (!detail) return null;
-  const fields = [];
-  const blocks = [];
-
-  if (detail.source === 'gupy') {
-    if (detail.published_at) fields.push(['Publicado em', detail.published_at]);
-    if (detail.country) fields.push(['País', detail.country]);
-    blocks.push(['Descrição', renderHtmlBlock(detail.description_html)]);
-    blocks.push(['Responsabilidades', renderHtmlBlock(detail.responsibilities_html)]);
-    blocks.push(['Pré-requisitos', renderHtmlBlock(detail.prerequisites_html)]);
-  } else if (detail.source === 'inhire') {
-    if (detail.contract_type) fields.push(['Contrato', detail.contract_type]);
-    if (detail.location) fields.push(['Localização', detail.location]);
-    if (detail.location_complement) fields.push(['Complemento', detail.location_complement]);
-    if (detail.published_at) fields.push(['Publicado em', detail.published_at]);
-    blocks.push(['Descrição', renderHtmlBlock(detail.description_html)]);
-    blocks.push(['Sobre a empresa', renderHtmlBlock(detail.about_html)]);
-  } else if (detail.source === 'linkedin') {
-    if (detail.seniority) fields.push(['Nível', detail.seniority]);
-    if (detail.employment_type) fields.push(['Tipo', detail.employment_type]);
-    blocks.push(['Descrição', renderTextBlock(detail.description)]);
-  }
+  const facts = extractCommonFacts(detail);
+  const blocks = sourceBlocks(detail).filter(([, body]) => body !== null);
+  const rawJson = pickRawJson(detail);
+  const syncedAgo = formatRelative(detail.fetched_at);
 
   return (
     <>
-      {fields.length > 0 && (
+      {facts.length > 0 && (
         <div className="detail-grid">
-          {fields.map(([label, value]) => (
+          {facts.map(({ label, value }) => (
             <div key={label} className="info-item">
               <strong>{label}:</strong>
               <span>{value}</span>
@@ -62,19 +66,19 @@ function SourceDetail({ detail }) {
           ))}
         </div>
       )}
-      {blocks.filter(([, body]) => body !== null).map(([label, body]) => (
+      {blocks.map(([label, body]) => (
         <section key={label} className="detail-section">
           <h4>{label}</h4>
           {body}
         </section>
       ))}
-      {detail.fetched_at && (
-        <p className="detail-meta">Sincronizado em {detail.fetched_at}</p>
+      {syncedAgo && (
+        <p className="detail-meta">Sincronizado {syncedAgo}</p>
       )}
-      {pickRawJson(detail) && (
+      {rawJson && (
         <details className="json-details">
           <summary>JSON completo da fonte</summary>
-          <JsonTree raw={pickRawJson(detail)} />
+          <JsonTree raw={rawJson} />
         </details>
       )}
     </>
@@ -107,6 +111,9 @@ function JobDetails({ job, detail, loading, error, company, onSync, onClose }) {
           <div>
             <h2>{job.job_title}</h2>
             <h3>{job.company_name}</h3>
+            {job.job_department && (
+              <p className="job-department">{job.job_department}</p>
+            )}
           </div>
         </div>
 

--- a/web/src/utils/detailFields.js
+++ b/web/src/utils/detailFields.js
@@ -1,0 +1,107 @@
+import { formatJobType, formatWorkplaceType } from './formatters';
+
+const DATE_FMT = new Intl.DateTimeFormat('pt-BR', {
+  day: '2-digit',
+  month: 'long',
+  year: 'numeric',
+});
+
+const DATETIME_FMT = new Intl.DateTimeFormat('pt-BR', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const RELATIVE_FMT = typeof Intl.RelativeTimeFormat === 'function'
+  ? new Intl.RelativeTimeFormat('pt-BR', { numeric: 'auto' })
+  : null;
+
+export function formatDate(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return DATE_FMT.format(d);
+}
+
+export function formatDateTime(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return DATETIME_FMT.format(d);
+}
+
+export function formatRelative(iso) {
+  if (!iso || !RELATIVE_FMT) return formatDateTime(iso);
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const diffMs = d.getTime() - Date.now();
+  const diffSec = Math.round(diffMs / 1000);
+  const abs = Math.abs(diffSec);
+  const units = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60],
+  ];
+  for (const [unit, secs] of units) {
+    if (abs >= secs) return RELATIVE_FMT.format(Math.round(diffSec / secs), unit);
+  }
+  return RELATIVE_FMT.format(diffSec, 'second');
+}
+
+export function formatCountry(code) {
+  if (!code) return null;
+  const v = code.trim().toUpperCase();
+  if (v === 'BRA' || v === 'BR' || v === 'BRAZIL') return 'Brasil';
+  return code;
+}
+
+export function formatSeniority(value) {
+  if (!value) return null;
+  const key = value.trim().toLowerCase();
+  const map = {
+    'internship': 'Estágio',
+    'entry level': 'Júnior',
+    'associate': 'Pleno',
+    'mid-senior level': 'Sênior',
+    'director': 'Diretoria',
+    'executive': 'Executivo',
+    'not applicable': null,
+  };
+  if (key in map) return map[key];
+  return value;
+}
+
+// Unifies the three source schemas into a single list of {label, value}
+// pairs so the UI can render a consistent "facts" grid. Each caller decides
+// which labels (if any) duplicate the outer modal header and filters them.
+export function extractCommonFacts(detail) {
+  if (!detail) return [];
+  const facts = [];
+  const push = (label, value) => {
+    if (value === null || value === undefined || value === '') return;
+    facts.push({ label, value });
+  };
+
+  if (detail.source === 'gupy') {
+    push('Publicado em', formatDate(detail.published_at));
+    push('Tipo de contratação', formatJobType(detail.job_type));
+    push('Modalidade', formatWorkplaceType(detail.workplace_type));
+    push('País', formatCountry(detail.country));
+  } else if (detail.source === 'inhire') {
+    push('Publicado em', formatDate(detail.published_at));
+    push('Tipo de contratação', formatJobType(detail.contract_type));
+    push('Modalidade', formatWorkplaceType(detail.workplace_type));
+    push('Localização', detail.location);
+    push('Complemento', detail.location_complement);
+  } else if (detail.source === 'linkedin') {
+    push('Nível', formatSeniority(detail.seniority));
+    push('Tipo de contratação', formatJobType(detail.employment_type));
+  }
+
+  return facts;
+}


### PR DESCRIPTION
## Summary
- Normalized detail fields across `jobs_gupy_detail`, `jobs_inhire_detail`, `jobs_linkedin_detail` into a shared extractor (`web/src/utils/detailFields.js`).
- Replaced per-source ad-hoc fact lists in `JobDetails.jsx` with one consistent facts grid — `Publicado em`, `Tipo de contratação`, `Modalidade`, `Nível` (LinkedIn), `País` (Gupy), `Complemento` (Inhire).
- Formatted `published_at` as localized date (`pt-BR`), mapped LinkedIn seniority values to Portuguese, and rendered `fetched_at` as relative time ("Sincronizado há X").
- Surfaced the job department in the modal header and gave the facts grid a subtle card background for hierarchy.

## Test plan
- [x] `docker compose build --no-cache web` — compiles with no new warnings.
- [x] API smoke test: `GET /api/health` and `GET /api/jobs/<id>/detail` for a pre-fetched Gupy row through the web proxy.
- [ ] Open the UI at http://localhost:8080, pick jobs from each source (Gupy / Inhire / LinkedIn), and confirm the facts grid renders the normalized labels and the rich HTML / text sections still display.
- [ ] Verify the LinkedIn sync path still works (requires `docker compose --profile linkedin up -d selenium linkedin-detail`).