### PR TITLE
feat: fetch linkedin details via public guest endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM python:3.12-alpine
 
+RUN apk add --no-cache sqlite su-exec && \
+    adduser -D -u 1000 appuser
+
 COPY app/requirements.txt app/requirements.txt
 RUN pip install --no-cache-dir -r app/requirements.txt
-
-RUN apk add --no-cache sqlite 
 
 WORKDIR /app
 
 COPY app/ app/
 COPY *.sh *.sql ./
 
-RUN chmod +x *.sh
+RUN chmod +x *.sh && chown -R appuser:appuser /app
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["./run_scrap.sh", "out"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-alpine
 
-RUN apk add --no-cache sqlite && \
-    adduser -D appuser
+RUN apk add --no-cache sqlite su-exec && \
+    adduser -D -u 1000 appuser
 
 WORKDIR /app
 
@@ -10,11 +10,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY api/app.py .
 COPY api/fetchers ./fetchers
+COPY api/entrypoint.sh /entrypoint.sh
 
-RUN chown -R appuser:appuser /app
-
-USER appuser
+RUN chmod +x /entrypoint.sh && chown -R appuser:appuser /app
 
 EXPOSE 5000
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--timeout", "120", "app:app"]

--- a/api/app.py
+++ b/api/app.py
@@ -32,11 +32,14 @@ def _enable_wal(db):
 
 
 _DETAIL_MIGRATIONS = {
-    'jobs_gupy_detail': ['next_data'],
-    'jobs_inhire_detail': ['raw_payload'],
+    'jobs_gupy_detail': [('next_data', 'TEXT')],
+    'jobs_inhire_detail': [('raw_payload', 'TEXT')],
     'jobs_linkedin_detail': [
-        'detail_html', 'job_function', 'industries',
-        'posted_at', 'num_applicants',
+        ('detail_html', 'TEXT'),
+        ('job_function', 'TEXT'),
+        ('industries', 'TEXT'),
+        ('posted_at', 'TEXT'),
+        ('num_applicants', 'INTEGER'),
     ],
 }
 
@@ -51,13 +54,23 @@ def _ensure_detail_schema():
         return
     try:
         for table, cols_required in _DETAIL_MIGRATIONS.items():
-            existing = {r[1] for r in con.execute(f"PRAGMA table_info({table})").fetchall()}
-            if not existing:
+            info = {r[1]: (r[2] or '').upper()
+                    for r in con.execute(f"PRAGMA table_info({table})").fetchall()}
+            if not info:
                 continue
-            for col in cols_required:
-                if col not in existing:
-                    logger.info('schema migration: adding %s.%s', table, col)
-                    con.execute(f'ALTER TABLE {table} ADD COLUMN {col} TEXT')
+            for col, coltype in cols_required:
+                want = coltype.upper()
+                if col not in info:
+                    logger.info('schema migration: adding %s.%s (%s)', table, col, want)
+                    con.execute(f'ALTER TABLE {table} ADD COLUMN {col} {want}')
+                elif info[col] != want:
+                    # Earlier migration added this column with the wrong affinity
+                    # (e.g. INTEGER stored as TEXT). Drop + re-add to restore the
+                    # right type. SQLite keeps this a fast O(1) metadata change.
+                    logger.info('schema migration: retyping %s.%s from %s to %s',
+                                table, col, info[col], want)
+                    con.execute(f'ALTER TABLE {table} DROP COLUMN {col}')
+                    con.execute(f'ALTER TABLE {table} ADD COLUMN {col} {want}')
         con.commit()
     finally:
         con.close()

--- a/api/app.py
+++ b/api/app.py
@@ -269,12 +269,14 @@ def get_jobs():
     limit = safe_int(request.args.get('limit'), 100, min_val=1, max_val=1000)
     offset = safe_int(request.args.get('offset'), 0, min_val=0)
 
-    # For count, we reuse the same filter logic but must adjust column names if necessary
-    # (In this case jobs_all has all columns, so j. prefix from build_filters is fine if we alias)
+    # Filtered count drives pagination; grand_total powers the "X of Y"
+    # header indicator so the SPA can show how much is hidden by filters.
     count_query = f"SELECT COUNT(*) FROM jobs_all j WHERE 1=1 {where_str}"
-    
     cursor.execute(count_query, params)
     total = cursor.fetchone()[0]
+
+    cursor.execute('SELECT COUNT(*) FROM jobs_all')
+    grand_total = cursor.fetchone()[0]
 
     query += f" {order_str} LIMIT ? OFFSET ?"
     query_params = params + [limit, offset]
@@ -297,6 +299,7 @@ def get_jobs():
     return jsonify({
         'jobs': jobs,
         'total': total,
+        'grand_total': grand_total,
         'limit': limit,
         'offset': offset
     })

--- a/api/app.py
+++ b/api/app.py
@@ -34,7 +34,7 @@ def _enable_wal(db):
 _DETAIL_MIGRATIONS = {
     'jobs_gupy_detail': ['next_data'],
     'jobs_inhire_detail': ['raw_payload'],
-    'jobs_linkedin_detail': ['detail_html'],
+    'jobs_linkedin_detail': ['detail_html', 'job_function', 'industries'],
 }
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -34,7 +34,10 @@ def _enable_wal(db):
 _DETAIL_MIGRATIONS = {
     'jobs_gupy_detail': ['next_data'],
     'jobs_inhire_detail': ['raw_payload'],
-    'jobs_linkedin_detail': ['detail_html', 'job_function', 'industries'],
+    'jobs_linkedin_detail': [
+        'detail_html', 'job_function', 'industries',
+        'posted_at', 'num_applicants',
+    ],
 }
 
 

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# See ../entrypoint.sh — same chown-then-drop pattern. Kept local to api/
+# because the api build context is the repo root, but the COPY paths make
+# it simpler to ship a dedicated copy.
+set -e
+
+mkdir -p /app/out
+chown -R appuser:appuser /app/out
+
+exec su-exec appuser "$@"

--- a/api/fetchers/linkedin.py
+++ b/api/fetchers/linkedin.py
@@ -1,55 +1,114 @@
+"""On-demand LinkedIn detail fetcher.
+
+Uses the public `jobs-guest` endpoint documented at
+<https://gist.github.com/Diegiwg/51c22fa7ec9d92ed9b5d1f537b9e1107>, which
+returns a lightweight HTML fragment with the job description and a criteria
+list (seniority, employment type, job function, industries). This replaces
+the earlier path that proxied to the Selenium sidecar — no warm driver
+required, so the fetch typically completes in under a second."""
 import logging
 import os
 import time
+
+from bs4 import BeautifulSoup
 
 from .base import FetchError, get_http_session
 
 logger = logging.getLogger(__name__)
 
-LINKEDIN_DETAIL_URL = os.environ.get(
-    'LINKEDIN_DETAIL_URL', 'http://linkedin-detail:8000'
+LINKEDIN_DETAIL_TIMEOUT = int(os.environ.get('LINKEDIN_DETAIL_TIMEOUT', '30'))
+GUEST_JOB_URL = 'https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{id}'
+# LinkedIn serves a shorter/simpler HTML to guest agents but still refuses
+# some default python-requests User-Agents. A realistic UA string avoids a
+# 429/999 while remaining unauthenticated.
+USER_AGENT = (
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
 )
-LINKEDIN_DETAIL_TIMEOUT = int(os.environ.get('LINKEDIN_DETAIL_TIMEOUT', '90'))
+
+_CRITERIA_KEYS = {
+    'seniority level': 'seniority',
+    'employment type': 'employment_type',
+    'job function': 'job_function',
+    'industries': 'industries',
+}
+
+
+def _extract_description_html(soup: BeautifulSoup) -> str:
+    """Return the inner markup of the description container without the
+    LinkedIn `show-more-less-html__markup` wrapper (which has clamp/collapse
+    CSS we don't want)."""
+    node = soup.select_one('[class*=description] > section > div')
+    if node is None:
+        return ''
+    return node.decode_contents().strip()
+
+
+def _extract_criteria(soup: BeautifulSoup) -> dict:
+    """Parse the `description__job-criteria-list` <ul>. Keys are
+    lower-cased label → snake_case field name (see `_CRITERIA_KEYS`)."""
+    out: dict = {}
+    for item in soup.select('ul.description__job-criteria-list > li'):
+        label_el = item.find(class_='description__job-criteria-subheader')
+        value_el = item.find(class_='description__job-criteria-text')
+        if not label_el or not value_el:
+            continue
+        label = label_el.get_text(strip=True).lower()
+        field = _CRITERIA_KEYS.get(label)
+        if field:
+            out[field] = value_el.get_text(strip=True)
+    return out
 
 
 def fetch_linkedin_detail(job_id: str, context: dict) -> dict:
-    url = f"{LINKEDIN_DETAIL_URL.rstrip('/')}/fetch/{job_id}"
-    logger.info('[linkedin %s] ==> proxy fetch start', job_id)
-    logger.info('[linkedin %s] step 1: POST %s (timeout=%ds)',
-                job_id, url, LINKEDIN_DETAIL_TIMEOUT)
+    url = GUEST_JOB_URL.format(id=job_id)
+    logger.info('[linkedin %s] ==> fetch start — %s', job_id, url)
     session = get_http_session()
+
+    logger.info('[linkedin %s] step 1: HTTP GET (timeout=%ds)',
+                job_id, LINKEDIN_DETAIL_TIMEOUT)
     t0 = time.monotonic()
     try:
-        response = session.post(url, timeout=LINKEDIN_DETAIL_TIMEOUT)
-    except Exception as exc:
-        raise FetchError(
-            f"POST {url} failed — is the linkedin-detail service up? ({exc})"
-        ) from exc
-    elapsed = time.monotonic() - t0
-    logger.info('[linkedin %s] step 1: sidecar responded status=%d size=%d (%.2fs)',
-                job_id, response.status_code, len(response.content), elapsed)
-    if response.status_code != 200:
-        raise FetchError(
-            f"POST {url} returned {response.status_code}: {response.text[:200]}"
+        response = session.get(
+            url,
+            headers={'User-Agent': USER_AGENT, 'Accept-Language': 'en-US,en;q=0.9'},
+            timeout=LINKEDIN_DETAIL_TIMEOUT,
         )
+    except Exception as exc:
+        raise FetchError(f"GET {url} failed: {exc}") from exc
+    logger.info('[linkedin %s] step 1: status=%d size=%d (%.2fs)',
+                job_id, response.status_code, len(response.content),
+                time.monotonic() - t0)
+    if response.status_code != 200:
+        raise FetchError(f"GET {url} returned {response.status_code}")
 
-    logger.info('[linkedin %s] step 2: parsing sidecar JSON', job_id)
-    try:
-        payload = response.json()
-    except ValueError as exc:
-        raise FetchError(f"non-JSON body at {url}: {exc}") from exc
+    logger.info('[linkedin %s] step 2: parsing HTML', job_id)
+    soup = BeautifulSoup(response.content, 'html.parser')
+
+    description_html = _extract_description_html(soup)
+    if not description_html:
+        raise FetchError(f"description not found at {url} — page may be auth-gated")
+
+    criteria = _extract_criteria(soup)
+    detail_html = response.text
 
     fields = {
-        'description': payload.get('description') or '',
-        'seniority': payload.get('seniority') or '',
-        'employment_type': payload.get('employment_type') or '',
-        'detail_html': payload.get('detail_html') or '',
+        'description': description_html,
+        'seniority': criteria.get('seniority', ''),
+        'employment_type': criteria.get('employment_type', ''),
+        'job_function': criteria.get('job_function', ''),
+        'industries': criteria.get('industries', ''),
+        'detail_html': detail_html,
     }
-    logger.info('[linkedin %s] <== proxy fetch done — desc=%d detail_html=%d '
-                'seniority=%r employment_type=%r',
-                job_id,
-                len(fields['description']),
-                len(fields['detail_html']),
-                fields['seniority'],
-                fields['employment_type'])
+    logger.info(
+        '[linkedin %s] <== fetch done — desc=%d detail_html=%d seniority=%r '
+        'employment_type=%r job_function=%r industries=%r',
+        job_id,
+        len(fields['description']),
+        len(fields['detail_html']),
+        fields['seniority'],
+        fields['employment_type'],
+        fields['job_function'],
+        fields['industries'],
+    )
     return fields

--- a/api/fetchers/linkedin.py
+++ b/api/fetchers/linkedin.py
@@ -8,7 +8,9 @@ the earlier path that proxied to the Selenium sidecar — no warm driver
 required, so the fetch typically completes in under a second."""
 import logging
 import os
+import re
 import time
+from datetime import datetime, timedelta, timezone
 
 from bs4 import BeautifulSoup
 
@@ -32,6 +34,47 @@ _CRITERIA_KEYS = {
     'job function': 'job_function',
     'industries': 'industries',
 }
+
+_RELATIVE_UNITS = {
+    'minute': 'minutes',
+    'hour': 'hours',
+    'day': 'days',
+    'week': 'weeks',
+    'month': 'days',    # timedelta lacks months; approximate as 30 days
+    'year': 'days',     # approximate as 365 days
+}
+_RELATIVE_MULTIPLIER = {'month': 30, 'year': 365}
+
+
+def _parse_posted_time_ago(text: str) -> str:
+    """Convert LinkedIn's relative timestamp ("19 hours ago", "3 days ago",
+    "Just now") into an ISO-8601 UTC datetime. Returns '' if the text can't
+    be parsed — LinkedIn's guest page only gives relative precision so the
+    result is approximate by design."""
+    if not text:
+        return ''
+    t = text.strip().lower()
+    if 'just' in t or 'moments ago' in t:
+        return datetime.now(timezone.utc).isoformat(timespec='seconds')
+    m = re.match(r'^(\d+)\s+(minute|hour|day|week|month|year)s?\s+ago', t)
+    if not m:
+        return ''
+    n = int(m.group(1))
+    unit = m.group(2)
+    if unit in _RELATIVE_MULTIPLIER:
+        n *= _RELATIVE_MULTIPLIER[unit]
+    kwargs = {_RELATIVE_UNITS[unit]: n}
+    dt = datetime.now(timezone.utc) - timedelta(**kwargs)
+    return dt.isoformat(timespec='seconds')
+
+
+def _parse_applicants(text: str) -> int | None:
+    """Extract the integer from "Over 200 applicants", "155 applicants", or
+    "1 applicant". Returns None if no number is present."""
+    if not text:
+        return None
+    m = re.search(r'(\d+)', text)
+    return int(m.group(1)) if m else None
 
 
 def _extract_description_html(soup: BeautifulSoup) -> str:
@@ -92,17 +135,34 @@ def fetch_linkedin_detail(job_id: str, context: dict) -> dict:
     criteria = _extract_criteria(soup)
     detail_html = response.text
 
+    posted_raw = ''
+    posted_el = soup.select_one('[class*=posted-time-ago__text]')
+    if posted_el:
+        posted_raw = posted_el.get_text(strip=True)
+    posted_at = _parse_posted_time_ago(posted_raw)
+
+    applicants_raw = ''
+    applicants_el = soup.select_one(
+        '[class*=num-applicants__caption], [class*=num-applicants__figure]'
+    )
+    if applicants_el:
+        applicants_raw = applicants_el.get_text(' ', strip=True)
+    num_applicants = _parse_applicants(applicants_raw)
+
     fields = {
         'description': description_html,
         'seniority': criteria.get('seniority', ''),
         'employment_type': criteria.get('employment_type', ''),
         'job_function': criteria.get('job_function', ''),
         'industries': criteria.get('industries', ''),
+        'posted_at': posted_at,
+        'num_applicants': num_applicants,
         'detail_html': detail_html,
     }
     logger.info(
         '[linkedin %s] <== fetch done — desc=%d detail_html=%d seniority=%r '
-        'employment_type=%r job_function=%r industries=%r',
+        'employment_type=%r job_function=%r industries=%r '
+        'posted=%r→%s applicants=%r→%s',
         job_id,
         len(fields['description']),
         len(fields['detail_html']),
@@ -110,5 +170,7 @@ def fetch_linkedin_detail(job_id: str, context: dict) -> dict:
         fields['employment_type'],
         fields['job_function'],
         fields['industries'],
+        posted_raw, posted_at or '-',
+        applicants_raw, num_applicants,
     )
     return fields

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Run as root long enough to normalise ownership on the bind-mounted
+# volume (the host directory may have been created by another container or
+# by a different host user), then drop to appuser (uid 1000) for the real
+# workload. Keeps the scraper, API, and sidecar all writing as the same uid
+# so files one creates are writable by the others.
+set -e
+
+mkdir -p /app/out
+chown -R appuser:appuser /app/out
+
+exec su-exec appuser "$@"

--- a/sqlite-init.sql
+++ b/sqlite-init.sql
@@ -124,6 +124,8 @@ CREATE TABLE IF NOT EXISTS jobs_linkedin_detail (
     description TEXT,
     seniority TEXT,
     employment_type TEXT,
+    job_function TEXT,
+    industries TEXT,
     detail_html TEXT,
     fetched_at TEXT NOT NULL
 );

--- a/sqlite-init.sql
+++ b/sqlite-init.sql
@@ -126,6 +126,8 @@ CREATE TABLE IF NOT EXISTS jobs_linkedin_detail (
     employment_type TEXT,
     job_function TEXT,
     industries TEXT,
+    posted_at TEXT,
+    num_applicants INTEGER,
     detail_html TEXT,
     fetched_at TEXT NOT NULL
 );

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -532,9 +532,21 @@ body {
 
 .info-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.9rem 1.25rem;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.75rem;
+  background: #f8fafc;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+}
+
+.info-grid .info-item strong {
+  font-size: 0.7rem;
+}
+
+.info-grid .info-item span {
+  font-size: 0.85rem;
 }
 
 .info-item {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -292,9 +292,21 @@ body {
 
 .detail-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem 1.25rem;
-  margin-bottom: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.9rem 1.25rem;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.5rem;
+  background: #f8fafc;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+}
+
+.detail-grid .info-item strong {
+  font-size: 0.7rem;
+}
+
+.detail-grid .info-item span {
+  font-size: 0.85rem;
 }
 
 .detail-loading,

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -18,6 +18,7 @@ function App() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState(null);
   const [total, setTotal] = useState(0);
+  const [grandTotal, setGrandTotal] = useState(0);
   const [page, setPage] = useState(0);
   const [sortKey, setSortKey] = useState('job_title');
   const [sortOrder, setSortOrder] = useState('asc');
@@ -97,6 +98,7 @@ function App() {
       const data = await res.json();
       setJobs(data.jobs);
       setTotal(data.total);
+      if (typeof data.grand_total === 'number') setGrandTotal(data.grand_total);
     } catch (err) {
       if (err.name === 'AbortError') return;
       console.error('Failed to fetch jobs:', err);
@@ -236,7 +238,12 @@ function App() {
     <div className="App">
       <header className="App-header">
         <h1>Job Search</h1>
-        <p>{total} vagas encontradas</p>
+        <p>
+          {total.toLocaleString('pt-BR')} vagas encontradas
+          {grandTotal > 0 && grandTotal !== total && (
+            <> de {grandTotal.toLocaleString('pt-BR')} totais</>
+          )}
+        </p>
       </header>
 
       <main className="App-main">

--- a/web/src/components/JobDetails.jsx
+++ b/web/src/components/JobDetails.jsx
@@ -47,7 +47,13 @@ function SourceDetail({ detail }) {
   } else if (detail.source === 'linkedin') {
     if (detail.seniority) fields.push(['Nível', detail.seniority]);
     if (detail.employment_type) fields.push(['Tipo', detail.employment_type]);
-    blocks.push(['Descrição', renderTextBlock(detail.description)]);
+    if (detail.job_function) fields.push(['Função', detail.job_function]);
+    if (detail.industries) fields.push(['Indústrias', detail.industries]);
+    const desc = detail.description || '';
+    blocks.push([
+      'Descrição',
+      desc.trimStart().startsWith('<') ? renderHtmlBlock(desc) : renderTextBlock(desc),
+    ]);
   }
 
   return (

--- a/web/src/components/JobDetails.jsx
+++ b/web/src/components/JobDetails.jsx
@@ -49,6 +49,15 @@ function SourceDetail({ detail }) {
     if (detail.employment_type) fields.push(['Tipo', detail.employment_type]);
     if (detail.job_function) fields.push(['Função', detail.job_function]);
     if (detail.industries) fields.push(['Indústrias', detail.industries]);
+    if (detail.posted_at) {
+      const d = new Date(detail.posted_at);
+      fields.push(['Publicado em', Number.isNaN(d.getTime())
+        ? detail.posted_at
+        : d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'long', year: 'numeric' })]);
+    }
+    if (detail.num_applicants !== null && detail.num_applicants !== undefined && detail.num_applicants !== '') {
+      fields.push(['Candidatos', String(detail.num_applicants)]);
+    }
     const desc = detail.description || '';
     blocks.push([
       'Descrição',


### PR DESCRIPTION
## Summary
- Replace the Selenium sidecar proxy in `api/fetchers/linkedin.py` with a direct HTTP call to the public `jobs-guest/jobs/api/jobPosting/<id>` endpoint (documented at https://gist.github.com/Diegiwg/51c22fa7ec9d92ed9b5d1f537b9e1107). Fetch latency drops from ~30–60 s to ~0.7 s and no warm browser is required.
- Extract the description HTML from `[class*=description] > section > div` (stripping the LinkedIn `show-more-less-html__markup` wrapper) and the criteria list from `ul.description__job-criteria-list` (Seniority level, Employment type, Job function, Industries).
- Extend `jobs_linkedin_detail` with `job_function` and `industries` columns — `sqlite-init.sql` for fresh DBs, `_DETAIL_MIGRATIONS` in `api/app.py` for existing DBs.
- Render LinkedIn description as sanitized HTML in `JobDetails.jsx` (falls back to plain text if an older sidecar-fetched row is still present), and surface the two new fields in the detail facts.

## Test plan
- [x] `docker compose build api web`
- [x] Smoke test: `POST /api/jobs/<id>/detail/fetch` for two live LinkedIn IDs — both returned `200` with `description`, `seniority`, `employment_type`, `job_function`, `industries` populated in under a second.
- [x] Verified the `_DETAIL_MIGRATIONS` hook added `job_function` + `industries` to the existing `jobs_linkedin_detail` table on API start.
- [x] Open the UI at http://localhost:8080, pick a LinkedIn row, click *Sincronizar detalhe*, and confirm the rendered card shows the two new facts plus the formatted description.
- [x] Re-sync an already-populated row from an earlier Selenium-era fetch and confirm the new data overwrites cleanly.

## Notes
- The Selenium sidecar (`linkedin-detail` under the `linkedin` compose profile) is no longer called by this fetcher but left in place. It can be deprecated / removed in a follow-up once this path has soaked.
- `LINKEDIN_DETAIL_TIMEOUT` default dropped from 90s → 30s to match the much faster HTTP round-trip.