### PR TITLE
feat(auth+tracker+theme): real auth, DB-backed tracker, dark theme toggle

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -28,6 +28,13 @@ LINKEDIN_WRITE_MODE=append
 # DEBUG=false
 # PORT=5000
 
+# Required for cookie session signing. Generate with:
+#   python -c 'import secrets; print(secrets.token_urlsafe(48))'
+SECRET_KEY=change-me-in-prod
+# Set to true when serving the SPA over HTTPS so the session cookie is Secure-only
+SESSION_COOKIE_SECURE=false
+# FLASK_ENV=production  # uncomment in prod to enforce SECRET_KEY presence
+
 # ── Web ────────────────────────────────────────────────────────────────────
 
 # API_URL=http://api:5000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,18 @@ Scraper (Python) ──▶ SQLite ◀── API (Flask/Gunicorn) ◀── Web (
 | `POST /api/jobs/<job_id>/detail/fetch` | On-demand fetch. Dispatches to `api/fetchers/{source}.py`; for LinkedIn, proxies to the sidecar. Upserts the row and returns it. 501 if the source isn't wired, 502 on upstream failure. |
 | `GET /api/companies` | — |
 | `GET /api/filters` | — |
+| `POST /api/auth/register` | Body `{username, password}`. 201 + sets cookie session. 409 if username exists. 400 on invalid password. |
+| `POST /api/auth/login` | Body `{username, password}`. 200 + cookie. 401 generic on bad credentials (no user enumeration). |
+| `POST /api/auth/logout` | 204; clears the session cookie. |
+| `GET /api/auth/me` | 200 with `{user: {id, username}}` if logged in, 401 otherwise. |
+| `GET /api/me/tracked` | `@login_required` — returns the caller's saved jobs (joined `tracked_jobs`). |
+| `POST /api/me/tracked` | `@login_required` — body is the snapshot from `web/src/App.js::jobRowToTracked`. Idempotent on `(user_id, job_id)`. |
+| `PATCH /api/me/tracked/<job_id>` | `@login_required` — body `{stage?, notes?}`. Validates `stage` against `STAGE_ORDER`; appends a timeline event when `stage` changes. |
+| `DELETE /api/me/tracked/<job_id>` | `@login_required` — 204 / 404. |
+
+### Auth model
+
+Cookie-session auth via `flask.session` (signed by `SECRET_KEY`, `HttpOnly`, `SameSite=Lax`, `Secure` when `SESSION_COOKIE_SECURE=true`). Password hashing via `werkzeug.security.generate_password_hash` / `check_password_hash` — no extra dep. Helpers and the `@login_required` decorator live in `api/auth.py`. The SPA reaches the API via the nginx proxy on the same origin, so cookies cross naturally; `web/src/utils/api.js::fetchJSON` always sets `credentials: 'include'`. Set `SECRET_KEY` in `.env` (sample in `.env_sample`).
 
 ### Database Pattern
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Customize behavior using environment variables in `docker-compose.yml` or a `.en
 | `LINKEDIN_KEYWORDS` | `Software Engineer` | LinkedIn search keywords |
 | `LINKEDIN_LOCATION` | `Brazil` | LinkedIn search location |
 | `JOBHUBMINE_DATABASE` | `/app/out/jobhubmine.db` | Container path to the SQLite database |
+| `SECRET_KEY` | `dev-only-insecure-secret` | **Required in prod**. Signs the auth cookie session. Generate with `python -c 'import secrets; print(secrets.token_urlsafe(48))'`. |
+| `SESSION_COOKIE_SECURE` | `false` | Set `true` when serving the SPA over HTTPS so the session cookie is `Secure`-only. |
 
 ## 🛠️ Development
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,6 +9,7 @@ COPY api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY api/app.py .
+COPY api/auth.py .
 COPY api/fetchers ./fetchers
 COPY api/entrypoint.sh /entrypoint.sh
 

--- a/api/app.py
+++ b/api/app.py
@@ -351,16 +351,14 @@ def auth_register():
     ok, reason = is_valid_password(password)
     if not ok:
         return jsonify({'error': reason}), 400
-    if not name or len(name) > 64:
-        return jsonify({'error': 'Nome é obrigatório (até 64 caracteres)'}), 400
-    if not surname or len(surname) > 64:
-        return jsonify({'error': 'Sobrenome é obrigatório (até 64 caracteres)'}), 400
+    if len(name) > 64 or len(surname) > 64:
+        return jsonify({'error': 'Nome/sobrenome muito longos (máx 64 caracteres)'}), 400
 
     db = get_db()
     try:
         cur = db.execute(
             'INSERT INTO users (username, password_hash, name, surname) VALUES (?, ?, ?, ?)',
-            (username, hash_password(password), name, surname),
+            (username, hash_password(password), name or None, surname or None),
         )
         db.commit()
     except sqlite3.IntegrityError:
@@ -369,7 +367,8 @@ def auth_register():
     user_id = cur.lastrowid
     _login_session(user_id)
     return jsonify({'user': {
-        'id': user_id, 'username': username, 'name': name, 'surname': surname,
+        'id': user_id, 'username': username,
+        'name': name or None, 'surname': surname or None,
     }}), 201
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -4,11 +4,33 @@ import sqlite3
 import json
 import logging
 import time
-from flask import Flask, request, jsonify, g
+from datetime import timedelta
+
+from flask import Flask, request, jsonify, g, session
 
 from fetchers import FETCHERS, FetchError
+from auth import (
+    current_user_id,
+    hash_password,
+    is_valid_password,
+    is_valid_username,
+    login_required,
+    verify_password,
+)
 
 app = Flask(__name__)
+
+_default_secret = 'dev-only-insecure-secret'
+app.secret_key = os.environ.get('SECRET_KEY') or _default_secret
+if app.secret_key == _default_secret and os.environ.get('FLASK_ENV') == 'production':
+    raise RuntimeError('SECRET_KEY env var is required in production')
+
+app.config['SESSION_COOKIE_HTTPONLY'] = True
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+app.config['SESSION_COOKIE_SECURE'] = (
+    os.environ.get('SESSION_COOKIE_SECURE', 'false').lower() == 'true'
+)
+app.permanent_session_lifetime = timedelta(days=30)
 
 logging.basicConfig(
     level=os.environ.get('LOG_LEVEL', 'INFO'),
@@ -262,6 +284,87 @@ def safe_int(val, default, min_val=None, max_val=None):
 @app.route('/api/health')
 def health():
     return jsonify({'status': 'ok'})
+
+
+def _user_payload(row) -> dict:
+    return {'id': row['id'], 'username': row['username']}
+
+
+def _login_session(user_id: int) -> None:
+    session.clear()
+    session['user_id'] = user_id
+    session.permanent = True
+
+
+def _generic_login_error():
+    return jsonify({'error': 'Usuário ou senha inválidos'}), 401
+
+
+@app.route('/api/auth/register', methods=['POST'])
+def auth_register():
+    body = request.get_json(silent=True) or {}
+    username = (body.get('username') or '').strip()
+    password = body.get('password') or ''
+
+    ok, reason = is_valid_username(username)
+    if not ok:
+        return jsonify({'error': reason}), 400
+    ok, reason = is_valid_password(password)
+    if not ok:
+        return jsonify({'error': reason}), 400
+
+    db = get_db()
+    try:
+        cur = db.execute(
+            'INSERT INTO users (username, password_hash) VALUES (?, ?)',
+            (username, hash_password(password)),
+        )
+        db.commit()
+    except sqlite3.IntegrityError:
+        return jsonify({'error': 'Esse usuário já existe'}), 409
+
+    user_id = cur.lastrowid
+    _login_session(user_id)
+    return jsonify({'user': {'id': user_id, 'username': username}}), 201
+
+
+@app.route('/api/auth/login', methods=['POST'])
+def auth_login():
+    body = request.get_json(silent=True) or {}
+    username = (body.get('username') or '').strip()
+    password = body.get('password') or ''
+    if not username or not password:
+        return _generic_login_error()
+
+    db = get_db()
+    row = db.execute(
+        'SELECT id, username, password_hash FROM users WHERE username = ? COLLATE NOCASE',
+        (username,),
+    ).fetchone()
+    if not row or not verify_password(password, row['password_hash']):
+        return _generic_login_error()
+
+    _login_session(row['id'])
+    return jsonify({'user': _user_payload(row)})
+
+
+@app.route('/api/auth/logout', methods=['POST'])
+def auth_logout():
+    session.clear()
+    return ('', 204)
+
+
+@app.route('/api/auth/me')
+def auth_me():
+    uid = current_user_id()
+    if uid is None:
+        return jsonify({'error': 'auth required'}), 401
+    db = get_db()
+    row = db.execute('SELECT id, username FROM users WHERE id = ?', (uid,)).fetchone()
+    if not row:
+        session.clear()
+        return jsonify({'error': 'auth required'}), 401
+    return jsonify({'user': _user_payload(row)})
 
 
 def get_job_url(job, company):

--- a/api/app.py
+++ b/api/app.py
@@ -114,10 +114,16 @@ def _ensure_app_schema():
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username TEXT NOT NULL UNIQUE COLLATE NOCASE,
                 password_hash TEXT NOT NULL,
+                name TEXT,
+                surname TEXT,
                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
             )
         """)
         con.execute("CREATE INDEX IF NOT EXISTS idx_users_username ON users(username)")
+        existing_user_cols = {r[1] for r in con.execute("PRAGMA table_info(users)").fetchall()}
+        for col in ('name', 'surname'):
+            if col not in existing_user_cols:
+                con.execute(f"ALTER TABLE users ADD COLUMN {col} TEXT")
         con.execute("""
             CREATE TABLE IF NOT EXISTS tracked_jobs (
                 user_id        INTEGER NOT NULL,
@@ -313,7 +319,12 @@ def health():
 
 
 def _user_payload(row) -> dict:
-    return {'id': row['id'], 'username': row['username']}
+    return {
+        'id': row['id'],
+        'username': row['username'],
+        'name': row['name'] if 'name' in row.keys() else None,
+        'surname': row['surname'] if 'surname' in row.keys() else None,
+    }
 
 
 def _login_session(user_id: int) -> None:
@@ -331,6 +342,8 @@ def auth_register():
     body = request.get_json(silent=True) or {}
     username = (body.get('username') or '').strip()
     password = body.get('password') or ''
+    name = (body.get('name') or '').strip()
+    surname = (body.get('surname') or '').strip()
 
     ok, reason = is_valid_username(username)
     if not ok:
@@ -338,12 +351,16 @@ def auth_register():
     ok, reason = is_valid_password(password)
     if not ok:
         return jsonify({'error': reason}), 400
+    if not name or len(name) > 64:
+        return jsonify({'error': 'Nome é obrigatório (até 64 caracteres)'}), 400
+    if not surname or len(surname) > 64:
+        return jsonify({'error': 'Sobrenome é obrigatório (até 64 caracteres)'}), 400
 
     db = get_db()
     try:
         cur = db.execute(
-            'INSERT INTO users (username, password_hash) VALUES (?, ?)',
-            (username, hash_password(password)),
+            'INSERT INTO users (username, password_hash, name, surname) VALUES (?, ?, ?, ?)',
+            (username, hash_password(password), name, surname),
         )
         db.commit()
     except sqlite3.IntegrityError:
@@ -351,7 +368,9 @@ def auth_register():
 
     user_id = cur.lastrowid
     _login_session(user_id)
-    return jsonify({'user': {'id': user_id, 'username': username}}), 201
+    return jsonify({'user': {
+        'id': user_id, 'username': username, 'name': name, 'surname': surname,
+    }}), 201
 
 
 @app.route('/api/auth/login', methods=['POST'])
@@ -364,7 +383,7 @@ def auth_login():
 
     db = get_db()
     row = db.execute(
-        'SELECT id, username, password_hash FROM users WHERE username = ? COLLATE NOCASE',
+        'SELECT id, username, password_hash, name, surname FROM users WHERE username = ?',
         (username,),
     ).fetchone()
     if not row or not verify_password(password, row['password_hash']):
@@ -386,7 +405,7 @@ def auth_me():
     if uid is None:
         return jsonify({'error': 'auth required'}), 401
     db = get_db()
-    row = db.execute('SELECT id, username FROM users WHERE id = ?', (uid,)).fetchone()
+    row = db.execute('SELECT id, username, name, surname FROM users WHERE id = ?', (uid,)).fetchone()
     if not row:
         session.clear()
         return jsonify({'error': 'auth required'}), 401

--- a/api/app.py
+++ b/api/app.py
@@ -118,6 +118,32 @@ def _ensure_app_schema():
             )
         """)
         con.execute("CREATE INDEX IF NOT EXISTS idx_users_username ON users(username)")
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS tracked_jobs (
+                user_id        INTEGER NOT NULL,
+                job_id         TEXT NOT NULL,
+                source         TEXT NOT NULL,
+                title          TEXT NOT NULL,
+                company_name   TEXT,
+                company_id     TEXT,
+                location       TEXT,
+                job_url        TEXT,
+                job_type       TEXT,
+                job_department TEXT,
+                workplace_type TEXT,
+                workplace_city TEXT,
+                workplace_state TEXT,
+                stage          TEXT NOT NULL DEFAULT 'salva',
+                notes          TEXT NOT NULL DEFAULT '',
+                events         TEXT NOT NULL DEFAULT '[]',
+                created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                PRIMARY KEY (user_id, job_id),
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )
+        """)
+        con.execute("CREATE INDEX IF NOT EXISTS idx_tracked_user ON tracked_jobs(user_id)")
+        con.execute("CREATE INDEX IF NOT EXISTS idx_tracked_user_stage ON tracked_jobs(user_id, stage)")
         con.commit()
     finally:
         con.close()

--- a/api/app.py
+++ b/api/app.py
@@ -393,6 +393,169 @@ def auth_me():
     return jsonify({'user': _user_payload(row)})
 
 
+# ── Tracker (saved jobs) ──────────────────────────────────────────────────
+
+STAGE_ORDER = ['salva', 'aplicada', 'entrev', 'prop', 'encer']
+STAGE_LABELS = {
+    'salva': 'Salva',
+    'aplicada': 'Aplicada',
+    'entrev': 'Entrevista',
+    'prop': 'Proposta',
+    'encer': 'Encerrada',
+}
+
+_TRACKER_FIELDS = (
+    'job_id', 'source', 'title', 'company_name', 'company_id', 'location',
+    'job_url', 'job_type', 'job_department', 'workplace_type',
+    'workplace_city', 'workplace_state', 'stage', 'notes', 'events',
+    'created_at', 'updated_at',
+)
+
+
+def _tracker_row_to_dict(row) -> dict:
+    out = {k: row[k] for k in _TRACKER_FIELDS}
+    try:
+        out['events'] = json.loads(out['events']) if out['events'] else []
+    except (TypeError, ValueError):
+        out['events'] = []
+    return out
+
+
+def _today_label() -> str:
+    from datetime import datetime
+    months = ['jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez']
+    now = datetime.now()
+    return f'{now.day:02d} {months[now.month - 1]}'
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z')
+
+
+@app.route('/api/me/tracked', methods=['GET'])
+@login_required
+def tracker_list():
+    db = get_db()
+    rows = db.execute(
+        f"SELECT {','.join(_TRACKER_FIELDS)} FROM tracked_jobs WHERE user_id = ? ORDER BY created_at",
+        (current_user_id(),),
+    ).fetchall()
+    return jsonify({'tracked': [_tracker_row_to_dict(r) for r in rows]})
+
+
+@app.route('/api/me/tracked', methods=['POST'])
+@login_required
+def tracker_add():
+    body = request.get_json(silent=True) or {}
+    job_id = (body.get('job_id') or body.get('id') or '').strip()
+    source = (body.get('source') or '').strip()
+    title = (body.get('title') or '').strip()
+    if not job_id or not source or not title:
+        return jsonify({'error': 'job_id, source e title são obrigatórios'}), 400
+
+    user_id = current_user_id()
+    db = get_db()
+    existing = db.execute(
+        f"SELECT {','.join(_TRACKER_FIELDS)} FROM tracked_jobs WHERE user_id = ? AND job_id = ?",
+        (user_id, job_id),
+    ).fetchone()
+    if existing:
+        return jsonify({'tracked': _tracker_row_to_dict(existing)})
+
+    events = json.dumps([{'when': _today_label(), 'what': 'Vaga salva'}])
+    now = _now_iso()
+    db.execute(
+        """INSERT INTO tracked_jobs
+           (user_id, job_id, source, title, company_name, company_id, location,
+            job_url, job_type, job_department, workplace_type,
+            workplace_city, workplace_state, stage, notes, events, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'salva', '', ?, ?, ?)""",
+        (
+            user_id, job_id, source, title,
+            body.get('company_name'), body.get('company_id'), body.get('location'),
+            body.get('job_url'), body.get('job_type'), body.get('job_department'),
+            body.get('workplace_type'), body.get('workplace_city'), body.get('workplace_state'),
+            events, now, now,
+        ),
+    )
+    db.commit()
+    row = db.execute(
+        f"SELECT {','.join(_TRACKER_FIELDS)} FROM tracked_jobs WHERE user_id = ? AND job_id = ?",
+        (user_id, job_id),
+    ).fetchone()
+    return jsonify({'tracked': _tracker_row_to_dict(row)}), 201
+
+
+@app.route('/api/me/tracked/<job_id>', methods=['PATCH'])
+@login_required
+def tracker_update(job_id):
+    body = request.get_json(silent=True) or {}
+    user_id = current_user_id()
+    db = get_db()
+    row = db.execute(
+        f"SELECT {','.join(_TRACKER_FIELDS)} FROM tracked_jobs WHERE user_id = ? AND job_id = ?",
+        (user_id, job_id),
+    ).fetchone()
+    if not row:
+        return jsonify({'error': 'not found'}), 404
+
+    sets = []
+    params = []
+    new_stage = body.get('stage')
+    new_notes = body.get('notes')
+
+    if new_stage is not None:
+        if new_stage not in STAGE_ORDER:
+            return jsonify({'error': f'stage inválido (use um de {STAGE_ORDER})'}), 400
+        if new_stage != row['stage']:
+            try:
+                events = json.loads(row['events']) if row['events'] else []
+            except (TypeError, ValueError):
+                events = []
+            events.append({'when': _today_label(), 'what': f'Movida para {STAGE_LABELS[new_stage]}'})
+            sets.append('stage = ?')
+            params.append(new_stage)
+            sets.append('events = ?')
+            params.append(json.dumps(events))
+
+    if new_notes is not None:
+        sets.append('notes = ?')
+        params.append(str(new_notes))
+
+    if not sets:
+        return jsonify({'tracked': _tracker_row_to_dict(row)})
+
+    sets.append('updated_at = ?')
+    params.append(_now_iso())
+    params.extend([user_id, job_id])
+    db.execute(
+        f"UPDATE tracked_jobs SET {', '.join(sets)} WHERE user_id = ? AND job_id = ?",
+        params,
+    )
+    db.commit()
+    row = db.execute(
+        f"SELECT {','.join(_TRACKER_FIELDS)} FROM tracked_jobs WHERE user_id = ? AND job_id = ?",
+        (user_id, job_id),
+    ).fetchone()
+    return jsonify({'tracked': _tracker_row_to_dict(row)})
+
+
+@app.route('/api/me/tracked/<job_id>', methods=['DELETE'])
+@login_required
+def tracker_remove(job_id):
+    user_id = current_user_id()
+    db = get_db()
+    cur = db.execute(
+        'DELETE FROM tracked_jobs WHERE user_id = ? AND job_id = ?',
+        (user_id, job_id),
+    )
+    db.commit()
+    if cur.rowcount == 0:
+        return jsonify({'error': 'not found'}), 404
+    return ('', 204)
+
+
 def get_job_url(job, company):
     source = job.get('source')
     job_id = job.get('id')

--- a/api/app.py
+++ b/api/app.py
@@ -79,6 +79,31 @@ def _ensure_detail_schema():
 _ensure_detail_schema()
 
 
+def _ensure_app_schema():
+    """Create app-state tables (users, tracked_jobs) if missing. Mirrors
+    sqlite-init.sql so the API works even when the file hasn't been re-applied."""
+    try:
+        con = sqlite3.connect(DATABASE)
+    except sqlite3.OperationalError:
+        return
+    try:
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE COLLATE NOCASE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            )
+        """)
+        con.execute("CREATE INDEX IF NOT EXISTS idx_users_username ON users(username)")
+        con.commit()
+    finally:
+        con.close()
+
+
+_ensure_app_schema()
+
+
 def get_db():
     db = getattr(g, '_database', None)
     if db is None:

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,50 @@
+"""Auth helpers: password hashing and validation, login_required decorator."""
+from functools import wraps
+from typing import Optional, Tuple
+
+from flask import jsonify, session
+from werkzeug.security import check_password_hash, generate_password_hash
+
+
+MIN_PASSWORD_LEN = 8
+
+
+def hash_password(plain: str) -> str:
+    return generate_password_hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    if not plain or not hashed:
+        return False
+    return check_password_hash(hashed, plain)
+
+
+def is_valid_password(plain: str) -> Tuple[bool, Optional[str]]:
+    if not isinstance(plain, str):
+        return False, 'Senha inválida'
+    if len(plain) < MIN_PASSWORD_LEN:
+        return False, f'Senha precisa ter ao menos {MIN_PASSWORD_LEN} caracteres'
+    if plain.strip() == '':
+        return False, 'Senha não pode ser vazia'
+    return True, None
+
+
+def is_valid_username(value: str) -> Tuple[bool, Optional[str]]:
+    if not isinstance(value, str) or not value.strip():
+        return False, 'Usuário é obrigatório'
+    if len(value) > 64:
+        return False, 'Usuário é muito longo'
+    return True, None
+
+
+def current_user_id() -> Optional[int]:
+    return session.get('user_id')
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        if current_user_id() is None:
+            return jsonify({'error': 'auth required'}), 401
+        return view(*args, **kwargs)
+    return wrapper

--- a/sqlite-init.sql
+++ b/sqlite-init.sql
@@ -326,6 +326,15 @@ CREATE VIEW job_details AS
     LEFT JOIN
         jobs_linkedin_detail ld ON j.source = 'linkedin' AND ld.id = j.id;
 
+-- 4. APP STATE (auth + tracker)
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+
 COMMIT;
 
 -- 5. ANALYTICS

--- a/sqlite-init.sql
+++ b/sqlite-init.sql
@@ -335,6 +335,31 @@ CREATE TABLE IF NOT EXISTS users (
 );
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
 
+CREATE TABLE IF NOT EXISTS tracked_jobs (
+    user_id        INTEGER NOT NULL,
+    job_id         TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    title          TEXT NOT NULL,
+    company_name   TEXT,
+    company_id     TEXT,
+    location       TEXT,
+    job_url        TEXT,
+    job_type       TEXT,
+    job_department TEXT,
+    workplace_type TEXT,
+    workplace_city TEXT,
+    workplace_state TEXT,
+    stage          TEXT NOT NULL DEFAULT 'salva',
+    notes          TEXT NOT NULL DEFAULT '',
+    events         TEXT NOT NULL DEFAULT '[]',
+    created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (user_id, job_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_tracked_user ON tracked_jobs(user_id);
+CREATE INDEX IF NOT EXISTS idx_tracked_user_stage ON tracked_jobs(user_id, stage);
+
 COMMIT;
 
 -- 5. ANALYTICS

--- a/sqlite-init.sql
+++ b/sqlite-init.sql
@@ -331,6 +331,8 @@ CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL UNIQUE COLLATE NOCASE,
     password_hash TEXT NOT NULL,
+    name TEXT,
+    surname TEXT,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -12,7 +12,7 @@
   border: 2px solid var(--border-color);
   border-radius: var(--radius);
   transition: all 0.2s;
-  background-color: white;
+  background-color: var(--jh-surface);
   box-shadow: var(--shadow-sm);
 }
 
@@ -35,7 +35,7 @@
   font-size: 0.875rem;
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
-  background-color: white;
+  background-color: var(--jh-surface);
   width: 180px;
   color: var(--text-main);
   cursor: pointer;
@@ -55,7 +55,7 @@
   font-size: 0.875rem;
   font-weight: 600;
   color: var(--danger);
-  background-color: white;
+  background-color: var(--jh-surface);
   border: 1px solid var(--danger);
   border-radius: 0.5rem;
   cursor: pointer;
@@ -85,7 +85,7 @@
 
 /* Table Styling */
 .job-table-container {
-  background-color: white;
+  background-color: var(--jh-surface);
   border-radius: var(--radius);
   border: 1px solid var(--border-color);
   box-shadow: var(--shadow);
@@ -98,7 +98,7 @@
 }
 
 .job-table th {
-  background-color: #f8fafc;
+  background-color: var(--jh-surface-2);
   padding: 1rem 1.5rem;
   text-align: left;
   font-size: 0.75rem;
@@ -122,7 +122,7 @@
 }
 
 .job-row:hover {
-  background-color: #f1f5f9;
+  background-color: var(--jh-surface-2);
 }
 
 .job-row td:first-child {
@@ -168,7 +168,7 @@
 }
 
 .tag-workplace-na {
-  background-color: #f1f5f9;
+  background-color: var(--jh-surface-2);
   color: #64748b;
 }
 
@@ -234,7 +234,7 @@
   gap: 0.9rem 1.25rem;
   padding: 1rem 1.1rem;
   margin-bottom: 1.5rem;
-  background: #f8fafc;
+  background: var(--jh-surface-2);
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
 }
@@ -288,7 +288,7 @@
   margin-top: 1.5rem;
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
-  background: #f8fafc;
+  background: var(--jh-surface-2);
 }
 
 .json-details > summary {
@@ -360,7 +360,7 @@
   align-items: center;
   gap: 1.5rem;
   padding: 1.5rem;
-  background-color: #f8fafc;
+  background-color: var(--jh-surface-2);
   border-top: 1px solid var(--border-color);
 }
 
@@ -370,7 +370,7 @@
   font-weight: 600;
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
-  background-color: white;
+  background-color: var(--jh-surface);
   color: var(--text-main);
   cursor: pointer;
   transition: all 0.2s;
@@ -409,7 +409,7 @@
 }
 
 .job-details-modal {
-  background-color: white;
+  background-color: var(--jh-surface);
   border-radius: 1rem;
   max-width: 700px;
   width: 100%;
@@ -433,7 +433,7 @@
   height: 2rem;
   border-radius: 50%;
   border: none;
-  background: #f1f5f9;
+  background: var(--jh-surface-2);
   font-size: 1.5rem;
   line-height: 1;
   cursor: pointer;
@@ -497,7 +497,7 @@
   gap: 0.9rem 1.25rem;
   padding: 1rem 1.1rem;
   margin-bottom: 1.75rem;
-  background: #f8fafc;
+  background: var(--jh-surface-2);
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
 }
@@ -569,7 +569,7 @@
 }
 
 .App-error button {
-  background: #fff;
+  background: var(--jh-surface);
   border: 1px solid var(--danger);
   color: var(--danger);
   padding: 0.4rem 0.75rem;

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -58,7 +58,7 @@ function trackedToSelectedJob(t) {
 function App() {
   const auth = useAuth();
   const { user, setUser } = useUser();
-  const { theme, cycle: cycleTheme } = useTheme();
+  const { theme, toggle: toggleTheme } = useTheme();
   const { toasts: toastList, push: pushToast, dismiss: dismissToast } = useToasts();
   const pushError = useCallback((message) => pushToast({ type: 'error', message }), [pushToast]);
   const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } =
@@ -290,7 +290,7 @@ function App() {
         user={user}
         onLogout={handleLogout}
         theme={theme}
-        onCycleTheme={cycleTheme}
+        onToggleTheme={toggleTheme}
       />
       <ToastTray toasts={toastList} onDismiss={dismissToast} />
       <main className="main">

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -59,13 +59,17 @@ function App() {
   const auth = useAuth();
   const { user, setUser } = useUser();
   const { theme, cycle: cycleTheme } = useTheme();
-  const toasts = useToasts();
-  const pushError = useCallback((message) => toasts.push({ type: 'error', message }), [toasts]);
+  const { toasts: toastList, push: pushToast, dismiss: dismissToast } = useToasts();
+  const pushError = useCallback((message) => pushToast({ type: 'error', message }), [pushToast]);
   const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } =
     useTrackedJobs(auth.status, pushError);
 
   useEffect(() => {
-    if (auth.user) setUser({ name: auth.user.username, email: '' });
+    if (auth.user) {
+      const displayName = [auth.user.name, auth.user.surname].filter(Boolean).join(' ')
+        || auth.user.username;
+      setUser({ name: displayName, email: '' });
+    }
   }, [auth.user, setUser]);
 
   const authed = auth.status === 'authenticated';
@@ -288,7 +292,7 @@ function App() {
         theme={theme}
         onCycleTheme={cycleTheme}
       />
-      <ToastTray toasts={toasts.toasts} onDismiss={toasts.dismiss} />
+      <ToastTray toasts={toastList} onDismiss={dismissToast} />
       <main className="main">
         {page === 'dashboard' && (
           <Dashboard

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -55,7 +55,9 @@ function trackedToSelectedJob(t) {
 function App() {
   const auth = useAuth();
   const { user, setUser } = useUser();
-  const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } = useTrackedJobs();
+  const [trackerError, setTrackerError] = useState(null);
+  const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } =
+    useTrackedJobs(auth.status, setTrackerError);
 
   useEffect(() => {
     if (auth.user) setUser({ name: auth.user.username, email: '' });
@@ -273,6 +275,11 @@ function App() {
   return (
     <div className="app">
       <Sidebar page={page} setPage={setPage} counts={counts} user={user} onLogout={handleLogout} />
+      {trackerError && (
+        <div role="status" aria-live="polite" className="tracker-error-banner" onClick={() => setTrackerError(null)}>
+          {trackerError}
+        </div>
+      )}
       <main className="main">
         {page === 'dashboard' && (
           <Dashboard

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -15,6 +15,7 @@ import useTrackedJobs from './hooks/useTrackedJobs';
 import useUser from './hooks/useUser';
 import useAuth from './hooks/useAuth';
 import useToasts from './hooks/useToasts';
+import useTheme from './hooks/useTheme';
 import { STAGE_NEXT } from './constants/stages';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
@@ -57,6 +58,7 @@ function trackedToSelectedJob(t) {
 function App() {
   const auth = useAuth();
   const { user, setUser } = useUser();
+  const { theme, cycle: cycleTheme } = useTheme();
   const toasts = useToasts();
   const pushError = useCallback((message) => toasts.push({ type: 'error', message }), [toasts]);
   const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } =
@@ -277,7 +279,15 @@ function App() {
 
   return (
     <div className="app">
-      <Sidebar page={page} setPage={setPage} counts={counts} user={user} onLogout={handleLogout} />
+      <Sidebar
+        page={page}
+        setPage={setPage}
+        counts={counts}
+        user={user}
+        onLogout={handleLogout}
+        theme={theme}
+        onCycleTheme={cycleTheme}
+      />
       <ToastTray toasts={toasts.toasts} onDismiss={toasts.dismiss} />
       <main className="main">
         {page === 'dashboard' && (

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -385,7 +385,7 @@ function App() {
         )}
 
         {page === 'settings' && (
-          <Settings user={user} setUser={setUser} />
+          <Settings user={auth.user} />
         )}
       </main>
 

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -12,6 +12,7 @@ import Settings from './components/Settings';
 import TrackedJobModal from './components/TrackedJobModal';
 import useTrackedJobs from './hooks/useTrackedJobs';
 import useUser from './hooks/useUser';
+import useAuth from './hooks/useAuth';
 import { STAGE_NEXT } from './constants/stages';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
@@ -52,10 +53,15 @@ function trackedToSelectedJob(t) {
 }
 
 function App() {
+  const auth = useAuth();
   const { user, setUser } = useUser();
   const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } = useTrackedJobs();
 
-  const [authed, setAuthed] = useState(() => localStorage.getItem('jh_authed') === '1');
+  useEffect(() => {
+    if (auth.user) setUser({ name: auth.user.username, email: '' });
+  }, [auth.user, setUser]);
+
+  const authed = auth.status === 'authenticated';
   const [page, setPage] = useState('dashboard');
 
   const [jobs, setJobs] = useState([]);
@@ -245,18 +251,17 @@ function App() {
   };
   const trackedFresh = trackedOpen ? trackedJobs.find((j) => j.id === trackedOpen.id) || null : null;
 
-  const handleEnter = ({ name }) => {
-    setUser({ name });
-    localStorage.setItem('jh_authed', '1');
-    setAuthed(true);
-  };
-  const handleLogout = () => {
-    localStorage.removeItem('jh_authed');
+  const handleLogout = async () => {
+    await auth.logout();
     setUser({ name: '', email: '' });
-    setAuthed(false);
   };
 
-  if (!authed) return <Login initialName={user.name} onEnter={handleEnter} />;
+  if (auth.status === 'loading') {
+    return <div className="login-shell"><div className="login-card">Carregando…</div></div>;
+  }
+  if (!authed) {
+    return <Login onLogin={auth.login} onRegister={auth.register} />;
+  }
 
   const counts = {
     saved: trackedJobs.filter((j) => j.stage === 'salva').length,

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -10,9 +10,11 @@ import SavedJobs from './components/SavedJobs';
 import Pipeline from './components/Pipeline';
 import Settings from './components/Settings';
 import TrackedJobModal from './components/TrackedJobModal';
+import ToastTray from './components/ToastTray';
 import useTrackedJobs from './hooks/useTrackedJobs';
 import useUser from './hooks/useUser';
 import useAuth from './hooks/useAuth';
+import useToasts from './hooks/useToasts';
 import { STAGE_NEXT } from './constants/stages';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
@@ -55,9 +57,10 @@ function trackedToSelectedJob(t) {
 function App() {
   const auth = useAuth();
   const { user, setUser } = useUser();
-  const [trackerError, setTrackerError] = useState(null);
+  const toasts = useToasts();
+  const pushError = useCallback((message) => toasts.push({ type: 'error', message }), [toasts]);
   const { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked } =
-    useTrackedJobs(auth.status, setTrackerError);
+    useTrackedJobs(auth.status, pushError);
 
   useEffect(() => {
     if (auth.user) setUser({ name: auth.user.username, email: '' });
@@ -275,11 +278,7 @@ function App() {
   return (
     <div className="app">
       <Sidebar page={page} setPage={setPage} counts={counts} user={user} onLogout={handleLogout} />
-      {trackerError && (
-        <div role="status" aria-live="polite" className="tracker-error-banner" onClick={() => setTrackerError(null)}>
-          {trackerError}
-        </div>
-      )}
+      <ToastTray toasts={toasts.toasts} onDismiss={toasts.dismiss} />
       <main className="main">
         {page === 'dashboard' && (
           <Dashboard

--- a/web/src/components/Login.jsx
+++ b/web/src/components/Login.jsx
@@ -5,6 +5,8 @@ function Login({ onLogin, onRegister }) {
   const [mode, setMode] = useState('login');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [surname, setSurname] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
@@ -16,7 +18,12 @@ function Login({ onLogin, onRegister }) {
     setSubmitting(true);
     try {
       if (isRegister) {
-        await onRegister(username.trim(), password);
+        await onRegister({
+          username: username.trim(),
+          password,
+          name: name.trim(),
+          surname: surname.trim(),
+        });
       } else {
         await onLogin(username.trim(), password);
       }
@@ -43,6 +50,32 @@ function Login({ onLogin, onRegister }) {
             : 'Acesse sua conta para ver suas vagas salvas e seu pipeline.'}
         </p>
 
+        {isRegister && (
+          <>
+            <div className="field">
+              <label htmlFor="login-name">Nome</label>
+              <input
+                id="login-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="given-name"
+                maxLength={64}
+                required
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="login-surname">Sobrenome</label>
+              <input
+                id="login-surname"
+                value={surname}
+                onChange={(e) => setSurname(e.target.value)}
+                autoComplete="family-name"
+                maxLength={64}
+                required
+              />
+            </div>
+          </>
+        )}
         <div className="field">
           <label htmlFor="login-username">Usuário</label>
           <input
@@ -50,7 +83,7 @@ function Login({ onLogin, onRegister }) {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             autoComplete="username"
-            autoFocus
+            autoFocus={!isRegister}
             required
           />
         </div>

--- a/web/src/components/Login.jsx
+++ b/web/src/components/Login.jsx
@@ -1,12 +1,30 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-function Login({ initialName, onEnter }) {
-  const [name, setName] = useState(initialName || '');
+function Login({ onLogin, onRegister }) {
+  const [mode, setMode] = useState('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
 
-  const submit = (e) => {
+  const isRegister = mode === 'register';
+
+  const submit = async (e) => {
     e.preventDefault();
-    onEnter({ name: name.trim() || 'Visitante' });
+    setError(null);
+    setSubmitting(true);
+    try {
+      if (isRegister) {
+        await onRegister(username.trim(), password);
+      } else {
+        await onLogin(username.trim(), password);
+      }
+    } catch (err) {
+      setError(err.message || 'Falha na operação');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -18,20 +36,60 @@ function Login({ initialName, onEnter }) {
             JobHub<span style={{ color: 'var(--jh-primary)' }}>Mine</span>
           </div>
         </div>
-        <h2>Entre para acompanhar suas vagas</h2>
-        <p className="lede">Suas candidaturas ficam salvas neste dispositivo. Sem cadastro.</p>
+        <h2>{isRegister ? 'Criar conta' : 'Entrar'}</h2>
+        <p className="lede">
+          {isRegister
+            ? 'Crie uma conta para salvar suas vagas e acompanhar candidaturas.'
+            : 'Acesse sua conta para ver suas vagas salvas e seu pipeline.'}
+        </p>
+
         <div className="field">
-          <label htmlFor="login-name">Como podemos te chamar?</label>
+          <label htmlFor="login-username">Usuário</label>
           <input
-            id="login-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            id="login-username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
             autoFocus
+            required
           />
         </div>
-        <button type="submit" className="btn btn-primary btn-block">Começar</button>
-        <p style={{ marginTop: '1rem', fontSize: '0.75rem', color: 'var(--jh-fg-subtle)', textAlign: 'center' }}>
-          Nenhum dado é enviado para servidores.
+        <div className="field">
+          <label htmlFor="login-password">Senha</label>
+          <input
+            id="login-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete={isRegister ? 'new-password' : 'current-password'}
+            required
+            minLength={isRegister ? 8 : undefined}
+          />
+        </div>
+
+        {error && (
+          <div role="alert" style={{ marginBottom: '0.75rem', color: 'var(--jh-danger)', fontSize: '0.8125rem' }}>
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          className="btn btn-primary btn-block"
+          disabled={submitting}
+        >
+          {submitting ? '…' : (isRegister ? 'Criar conta' : 'Entrar')}
+        </button>
+
+        <p style={{ marginTop: '1rem', fontSize: '0.75rem', textAlign: 'center', color: 'var(--jh-fg-muted)' }}>
+          {isRegister ? 'Já tem uma conta?' : 'Ainda não tem uma conta?'}{' '}
+          <button
+            type="button"
+            className="link-btn"
+            onClick={() => { setError(null); setMode(isRegister ? 'login' : 'register'); }}
+          >
+            {isRegister ? 'Entrar' : 'Criar conta'}
+          </button>
         </p>
       </form>
     </div>
@@ -39,12 +97,8 @@ function Login({ initialName, onEnter }) {
 }
 
 Login.propTypes = {
-  initialName: PropTypes.string,
-  onEnter: PropTypes.func.isRequired,
-};
-
-Login.defaultProps = {
-  initialName: '',
+  onLogin: PropTypes.func.isRequired,
+  onRegister: PropTypes.func.isRequired,
 };
 
 export default Login;

--- a/web/src/components/Login.jsx
+++ b/web/src/components/Login.jsx
@@ -53,25 +53,23 @@ function Login({ onLogin, onRegister }) {
         {isRegister && (
           <>
             <div className="field">
-              <label htmlFor="login-name">Nome</label>
+              <label htmlFor="login-name">Nome <span style={{ color: 'var(--jh-fg-subtle)', textTransform: 'none', fontWeight: 400 }}>(opcional)</span></label>
               <input
                 id="login-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 autoComplete="given-name"
                 maxLength={64}
-                required
               />
             </div>
             <div className="field">
-              <label htmlFor="login-surname">Sobrenome</label>
+              <label htmlFor="login-surname">Sobrenome <span style={{ color: 'var(--jh-fg-subtle)', textTransform: 'none', fontWeight: 400 }}>(opcional)</span></label>
               <input
                 id="login-surname"
                 value={surname}
                 onChange={(e) => setSurname(e.target.value)}
                 autoComplete="family-name"
                 maxLength={64}
-                required
               />
             </div>
           </>

--- a/web/src/components/Settings.jsx
+++ b/web/src/components/Settings.jsx
@@ -15,8 +15,16 @@ function Settings({ user }) {
           <label>Usuário</label>
           <input value={user?.username || ''} readOnly />
         </div>
+        <div className="field">
+          <label>Nome</label>
+          <input value={user?.name || ''} readOnly />
+        </div>
+        <div className="field">
+          <label>Sobrenome</label>
+          <input value={user?.surname || ''} readOnly />
+        </div>
         <p style={{ fontSize: '0.75rem', color: 'var(--jh-fg-muted)', margin: '0.5rem 0 0' }}>
-          Mais opções (alterar senha, preferências) em breve.
+          Mais opções (alterar senha, edição de dados) em breve.
         </p>
       </div>
     </>
@@ -27,6 +35,8 @@ Settings.propTypes = {
   user: PropTypes.shape({
     id: PropTypes.number,
     username: PropTypes.string,
+    name: PropTypes.string,
+    surname: PropTypes.string,
   }),
 };
 

--- a/web/src/components/Settings.jsx
+++ b/web/src/components/Settings.jsx
@@ -1,33 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Settings({ user, setUser }) {
+function Settings({ user }) {
   return (
     <>
       <div className="page-head">
         <div>
           <h2>Configurações</h2>
-          <p>Suas preferências são salvas localmente.</p>
+          <p>Conta logada e preferências do dispositivo.</p>
         </div>
       </div>
       <div className="card card-pad" style={{ maxWidth: 600 }}>
         <div className="field">
-          <label htmlFor="settings-name">Nome</label>
-          <input
-            id="settings-name"
-            value={user.name}
-            onChange={(e) => setUser({ name: e.target.value })}
-          />
+          <label>Usuário</label>
+          <input value={user?.username || ''} readOnly />
         </div>
-        <div className="field">
-          <label htmlFor="settings-email">Email</label>
-          <input
-            id="settings-email"
-            type="email"
-            value={user.email}
-            onChange={(e) => setUser({ email: e.target.value })}
-          />
-        </div>
+        <p style={{ fontSize: '0.75rem', color: 'var(--jh-fg-muted)', margin: '0.5rem 0 0' }}>
+          Mais opções (alterar senha, preferências) em breve.
+        </p>
       </div>
     </>
   );
@@ -35,10 +25,13 @@ function Settings({ user, setUser }) {
 
 Settings.propTypes = {
   user: PropTypes.shape({
-    name: PropTypes.string,
-    email: PropTypes.string,
-  }).isRequired,
-  setUser: PropTypes.func.isRequired,
+    id: PropTypes.number,
+    username: PropTypes.string,
+  }),
+};
+
+Settings.defaultProps = {
+  user: null,
 };
 
 export default Settings;

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -35,10 +35,34 @@ NavItem.defaultProps = {
   active: false,
 };
 
-const THEME_LABELS = { system: 'Tema: sistema', light: 'Tema: claro', dark: 'Tema: escuro' };
-const THEME_ICONS = { system: '◐', light: '☀', dark: '☾' };
+function ThemeSwitch({ theme, onToggle }) {
+  const isDark = theme === 'dark';
+  return (
+    <div className="theme-switch">
+      <span className="theme-switch-label">
+        <span aria-hidden="true">{isDark ? '☾' : '☀'}</span>
+        {isDark ? 'Escuro' : 'Claro'}
+      </span>
+      <button
+        type="button"
+        className={'theme-switch-toggle' + (isDark ? ' is-on' : '')}
+        role="switch"
+        aria-checked={isDark}
+        aria-label="Alternar tema"
+        onClick={onToggle}
+      >
+        <span className="theme-switch-knob" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
 
-function Sidebar({ page, setPage, counts, user, onLogout, theme, onCycleTheme }) {
+ThemeSwitch.propTypes = {
+  theme: PropTypes.oneOf(['light', 'dark']).isRequired,
+  onToggle: PropTypes.func.isRequired,
+};
+
+function Sidebar({ page, setPage, counts, user, onLogout, theme, onToggleTheme }) {
   const initial = (user.name?.trim()?.[0] || '?').toUpperCase();
   const [menuOpen, setMenuOpen] = useState(false);
   const footRef = useRef(null);
@@ -70,6 +94,22 @@ function Sidebar({ page, setPage, counts, user, onLogout, theme, onCycleTheme })
       <NavItem icon="▦" label="Pipeline" count={counts.pipeline} active={page === 'pipeline'} onClick={() => setPage('pipeline')} />
 
       <div className="sidebar-foot" ref={footRef}>
+        {menuOpen && (
+          <div className="sidebar-foot-actions" role="menu">
+            <NavItem
+              icon="⚙"
+              label="Configurações"
+              active={page === 'settings'}
+              onClick={() => { setMenuOpen(false); setPage('settings'); }}
+            />
+            <ThemeSwitch theme={theme} onToggle={onToggleTheme} />
+            <NavItem
+              icon="⏻"
+              label="Sair"
+              onClick={() => { setMenuOpen(false); onLogout(); }}
+            />
+          </div>
+        )}
         <button
           type="button"
           className={'sidebar-foot-user' + (menuOpen ? ' is-open' : '')}
@@ -82,28 +122,8 @@ function Sidebar({ page, setPage, counts, user, onLogout, theme, onCycleTheme })
             <div style={{ fontWeight: 600, color: 'var(--jh-fg)' }}>{user.name || 'Visitante'}</div>
             <div>{user.email || ''}</div>
           </div>
-          <span className="sidebar-foot-caret" aria-hidden="true">{menuOpen ? '▾' : '▸'}</span>
+          <span className="sidebar-foot-caret" aria-hidden="true">{menuOpen ? '▴' : '▸'}</span>
         </button>
-        {menuOpen && (
-          <div className="sidebar-foot-actions" role="menu">
-            <NavItem
-              icon="⚙"
-              label="Configurações"
-              active={page === 'settings'}
-              onClick={() => { setMenuOpen(false); setPage('settings'); }}
-            />
-            <NavItem
-              icon={THEME_ICONS[theme]}
-              label={THEME_LABELS[theme]}
-              onClick={onCycleTheme}
-            />
-            <NavItem
-              icon="⏻"
-              label="Sair"
-              onClick={() => { setMenuOpen(false); onLogout(); }}
-            />
-          </div>
-        )}
       </div>
     </aside>
   );
@@ -121,8 +141,8 @@ Sidebar.propTypes = {
     email: PropTypes.string,
   }).isRequired,
   onLogout: PropTypes.func.isRequired,
-  theme: PropTypes.oneOf(['system', 'light', 'dark']).isRequired,
-  onCycleTheme: PropTypes.func.isRequired,
+  theme: PropTypes.oneOf(['light', 'dark']).isRequired,
+  onToggleTheme: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -35,7 +35,10 @@ NavItem.defaultProps = {
   active: false,
 };
 
-function Sidebar({ page, setPage, counts, user, onLogout }) {
+const THEME_LABELS = { system: 'Tema: sistema', light: 'Tema: claro', dark: 'Tema: escuro' };
+const THEME_ICONS = { system: '◐', light: '☀', dark: '☾' };
+
+function Sidebar({ page, setPage, counts, user, onLogout, theme, onCycleTheme }) {
   const initial = (user.name?.trim()?.[0] || '?').toUpperCase();
   const [menuOpen, setMenuOpen] = useState(false);
   const footRef = useRef(null);
@@ -90,6 +93,11 @@ function Sidebar({ page, setPage, counts, user, onLogout }) {
               onClick={() => { setMenuOpen(false); setPage('settings'); }}
             />
             <NavItem
+              icon={THEME_ICONS[theme]}
+              label={THEME_LABELS[theme]}
+              onClick={onCycleTheme}
+            />
+            <NavItem
               icon="⏻"
               label="Sair"
               onClick={() => { setMenuOpen(false); onLogout(); }}
@@ -113,6 +121,8 @@ Sidebar.propTypes = {
     email: PropTypes.string,
   }).isRequired,
   onLogout: PropTypes.func.isRequired,
+  theme: PropTypes.oneOf(['system', 'light', 'dark']).isRequired,
+  onCycleTheme: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/web/src/components/ToastTray.jsx
+++ b/web/src/components/ToastTray.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ToastTray({ toasts, onDismiss }) {
+  if (!toasts.length) return null;
+  return (
+    <div className="toast-tray" role="status" aria-live="polite">
+      {toasts.map((t) => (
+        <div key={t.id} className={`toast toast-${t.type}`}>
+          <span>{t.message}</span>
+          <button type="button" className="toast-close" aria-label="Fechar" onClick={() => onDismiss(t.id)}>
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+ToastTray.propTypes = {
+  toasts: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    type: PropTypes.string,
+    message: PropTypes.string.isRequired,
+  })).isRequired,
+  onDismiss: PropTypes.func.isRequired,
+};
+
+export default ToastTray;

--- a/web/src/hooks/useAuth.js
+++ b/web/src/hooks/useAuth.js
@@ -32,10 +32,10 @@ export default function useAuth() {
     return data.user;
   }, []);
 
-  const register = useCallback(async (username, password) => {
+  const register = useCallback(async (payload) => {
     const data = await fetchJSON('/auth/register', {
       method: 'POST',
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify(payload),
     });
     setUser(data.user);
     setStatus('authenticated');

--- a/web/src/hooks/useAuth.js
+++ b/web/src/hooks/useAuth.js
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ApiError, fetchJSON } from '../utils/api';
+
+export default function useAuth() {
+  const [user, setUser] = useState(null);
+  const [status, setStatus] = useState('loading');
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetchJSON('/api/auth/me');
+      setUser(data.user);
+      setStatus('authenticated');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setUser(null);
+        setStatus('anonymous');
+        return;
+      }
+      setStatus('anonymous');
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const login = useCallback(async (username, password) => {
+    const data = await fetchJSON('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
+    });
+    setUser(data.user);
+    setStatus('authenticated');
+    return data.user;
+  }, []);
+
+  const register = useCallback(async (username, password) => {
+    const data = await fetchJSON('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
+    });
+    setUser(data.user);
+    setStatus('authenticated');
+    return data.user;
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await fetchJSON('/api/auth/logout', { method: 'POST' });
+    } catch {
+      // ignore — local state is what matters for the SPA
+    }
+    setUser(null);
+    setStatus('anonymous');
+  }, []);
+
+  return { user, status, login, register, logout, refresh };
+}

--- a/web/src/hooks/useAuth.js
+++ b/web/src/hooks/useAuth.js
@@ -7,7 +7,7 @@ export default function useAuth() {
 
   const refresh = useCallback(async () => {
     try {
-      const data = await fetchJSON('/api/auth/me');
+      const data = await fetchJSON('/auth/me');
       setUser(data.user);
       setStatus('authenticated');
     } catch (err) {
@@ -23,7 +23,7 @@ export default function useAuth() {
   useEffect(() => { refresh(); }, [refresh]);
 
   const login = useCallback(async (username, password) => {
-    const data = await fetchJSON('/api/auth/login', {
+    const data = await fetchJSON('/auth/login', {
       method: 'POST',
       body: JSON.stringify({ username, password }),
     });
@@ -33,7 +33,7 @@ export default function useAuth() {
   }, []);
 
   const register = useCallback(async (username, password) => {
-    const data = await fetchJSON('/api/auth/register', {
+    const data = await fetchJSON('/auth/register', {
       method: 'POST',
       body: JSON.stringify({ username, password }),
     });
@@ -44,7 +44,7 @@ export default function useAuth() {
 
   const logout = useCallback(async () => {
     try {
-      await fetchJSON('/api/auth/logout', { method: 'POST' });
+      await fetchJSON('/auth/logout', { method: 'POST' });
     } catch {
       // ignore — local state is what matters for the SPA
     }

--- a/web/src/hooks/useTheme.js
+++ b/web/src/hooks/useTheme.js
@@ -1,55 +1,40 @@
 import { useCallback, useEffect, useState } from 'react';
 
 const STORAGE_KEY = 'jh_theme';
-const VALID = ['system', 'light', 'dark'];
-
-const readInitial = () => {
-  try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    return VALID.includes(v) ? v : 'system';
-  } catch {
-    return 'system';
-  }
-};
+const VALID = ['light', 'dark'];
 
 const prefersDark = () => {
   if (typeof window === 'undefined' || !window.matchMedia) return false;
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 };
 
+const readInitial = () => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (VALID.includes(v)) return v;
+  } catch { /* ignore */ }
+  return prefersDark() ? 'dark' : 'light';
+};
+
 const apply = (theme) => {
-  const effective = theme === 'system' ? (prefersDark() ? 'dark' : 'light') : theme;
-  document.documentElement.setAttribute('data-theme', effective);
-  return effective;
+  document.documentElement.setAttribute('data-theme', theme);
 };
 
 export default function useTheme() {
   const [theme, setThemeState] = useState(readInitial);
-  const [effective, setEffective] = useState(() => apply(readInitial()));
 
   useEffect(() => {
-    setEffective(apply(theme));
+    apply(theme);
     try { localStorage.setItem(STORAGE_KEY, theme); } catch { /* ignore */ }
-  }, [theme]);
-
-  useEffect(() => {
-    if (theme !== 'system' || !window.matchMedia) return undefined;
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const onChange = () => setEffective(apply('system'));
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
   }, [theme]);
 
   const setTheme = useCallback((next) => {
     if (VALID.includes(next)) setThemeState(next);
   }, []);
 
-  const cycle = useCallback(() => {
-    setThemeState((prev) => {
-      const idx = VALID.indexOf(prev);
-      return VALID[(idx + 1) % VALID.length];
-    });
+  const toggle = useCallback(() => {
+    setThemeState((prev) => (prev === 'dark' ? 'light' : 'dark'));
   }, []);
 
-  return { theme, effective, setTheme, cycle };
+  return { theme, setTheme, toggle };
 }

--- a/web/src/hooks/useTheme.js
+++ b/web/src/hooks/useTheme.js
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'jh_theme';
+const VALID = ['system', 'light', 'dark'];
+
+const readInitial = () => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return VALID.includes(v) ? v : 'system';
+  } catch {
+    return 'system';
+  }
+};
+
+const prefersDark = () => {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+};
+
+const apply = (theme) => {
+  const effective = theme === 'system' ? (prefersDark() ? 'dark' : 'light') : theme;
+  document.documentElement.setAttribute('data-theme', effective);
+  return effective;
+};
+
+export default function useTheme() {
+  const [theme, setThemeState] = useState(readInitial);
+  const [effective, setEffective] = useState(() => apply(readInitial()));
+
+  useEffect(() => {
+    setEffective(apply(theme));
+    try { localStorage.setItem(STORAGE_KEY, theme); } catch { /* ignore */ }
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme !== 'system' || !window.matchMedia) return undefined;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => setEffective(apply('system'));
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, [theme]);
+
+  const setTheme = useCallback((next) => {
+    if (VALID.includes(next)) setThemeState(next);
+  }, []);
+
+  const cycle = useCallback(() => {
+    setThemeState((prev) => {
+      const idx = VALID.indexOf(prev);
+      return VALID[(idx + 1) % VALID.length];
+    });
+  }, []);
+
+  return { theme, effective, setTheme, cycle };
+}

--- a/web/src/hooks/useToasts.js
+++ b/web/src/hooks/useToasts.js
@@ -1,0 +1,32 @@
+import { useCallback, useRef, useState } from 'react';
+
+const DEFAULT_TIMEOUT = 4000;
+
+export default function useToasts() {
+  const [toasts, setToasts] = useState([]);
+  const timersRef = useRef(new Map());
+
+  const dismiss = useCallback((id) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const push = useCallback((toast) => {
+    const id = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const next = {
+      id,
+      type: toast.type || 'error',
+      message: typeof toast === 'string' ? toast : toast.message,
+    };
+    setToasts((prev) => [...prev, next]);
+    const timer = setTimeout(() => dismiss(id), toast.timeout || DEFAULT_TIMEOUT);
+    timersRef.current.set(id, timer);
+    return id;
+  }, [dismiss]);
+
+  return { toasts, push, dismiss };
+}

--- a/web/src/hooks/useTrackedJobs.js
+++ b/web/src/hooks/useTrackedJobs.js
@@ -1,66 +1,136 @@
 import { useCallback, useEffect, useState } from 'react';
-import { STAGE_META } from '../constants/stages';
+import { ApiError, fetchJSON } from '../utils/api';
 
-const STORAGE_KEY = 'jh_jobs';
+const trackedToLocal = (t) => ({
+  id: String(t.job_id),
+  title: t.title,
+  company: t.company_name || '',
+  company_id: t.company_id,
+  location: t.location || '',
+  source: t.source || '',
+  ago: t.created_at ? '' : 'agora',
+  job_url: t.job_url,
+  workplace_city: t.workplace_city,
+  workplace_state: t.workplace_state,
+  workplace_type: t.workplace_type,
+  job_type: t.job_type,
+  job_department: t.job_department,
+  stage: t.stage,
+  notes: t.notes || '',
+  events: Array.isArray(t.events) ? t.events : [],
+});
 
-const readInitial = () => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
-};
+const localToServer = (job) => ({
+  job_id: job.id,
+  source: job.source,
+  title: job.title,
+  company_name: job.company,
+  company_id: job.company_id,
+  location: job.location,
+  job_url: job.job_url,
+  job_type: job.job_type,
+  job_department: job.job_department,
+  workplace_type: job.workplace_type,
+  workplace_city: job.workplace_city,
+  workplace_state: job.workplace_state,
+});
 
-const todayLabel = () => new Date().toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+export default function useTrackedJobs(authStatus, onError) {
+  const [trackedJobs, setTrackedJobs] = useState([]);
+  const [loaded, setLoaded] = useState(false);
 
-export default function useTrackedJobs() {
-  const [trackedJobs, setTrackedJobs] = useState(readInitial);
+  const reportError = useCallback((message) => {
+    if (typeof onError === 'function') onError(message);
+  }, [onError]);
 
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(trackedJobs));
-    } catch {
-      // QuotaExceededError or storage disabled — silently drop the persist.
+    if (authStatus !== 'authenticated') {
+      setTrackedJobs([]);
+      setLoaded(false);
+      return undefined;
     }
-  }, [trackedJobs]);
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchJSON('/api/me/tracked');
+        if (cancelled) return;
+        setTrackedJobs((data?.tracked || []).map(trackedToLocal));
+        setLoaded(true);
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 401) return;
+        reportError('Falha ao carregar vagas salvas.');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [authStatus, reportError]);
 
-  const addJob = useCallback((job) => {
-    setTrackedJobs((prev) => {
-      if (prev.some((j) => j.id === job.id)) return prev;
-      return [...prev, {
-        stage: 'salva',
-        notes: '',
-        events: [{ when: todayLabel(), what: 'Vaga salva' }],
-        ...job,
-      }];
-    });
-  }, []);
+  const addJob = useCallback(async (job) => {
+    if (trackedJobs.some((j) => j.id === job.id)) return;
+    const optimistic = {
+      ...job,
+      stage: 'salva',
+      notes: '',
+      events: [{ when: 'agora', what: 'Vaga salva' }],
+    };
+    setTrackedJobs((prev) => [...prev, optimistic]);
+    try {
+      const data = await fetchJSON('/api/me/tracked', {
+        method: 'POST',
+        body: JSON.stringify(localToServer(job)),
+      });
+      const fresh = trackedToLocal(data.tracked);
+      setTrackedJobs((prev) => prev.map((j) => (j.id === fresh.id ? fresh : j)));
+    } catch (err) {
+      setTrackedJobs((prev) => prev.filter((j) => j.id !== job.id));
+      reportError(`Não foi possível salvar a vaga: ${err.message}`);
+    }
+  }, [trackedJobs, reportError]);
 
-  const updateStage = useCallback((id, stage) => {
-    setTrackedJobs((prev) => prev.map((j) => (
-      j.id === id
-        ? {
-            ...j,
-            stage,
-            events: [
-              ...(j.events || []),
-              { when: todayLabel(), what: `Movida para ${STAGE_META[stage]?.label || stage}` },
-            ],
-          }
-        : j
-    )));
-  }, []);
+  const updateStage = useCallback(async (id, stage) => {
+    const prevSnapshot = trackedJobs;
+    setTrackedJobs((prev) => prev.map((j) => (j.id === id ? { ...j, stage } : j)));
+    try {
+      const data = await fetchJSON(`/api/me/tracked/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ stage }),
+      });
+      const fresh = trackedToLocal(data.tracked);
+      setTrackedJobs((prev) => prev.map((j) => (j.id === fresh.id ? fresh : j)));
+    } catch (err) {
+      setTrackedJobs(prevSnapshot);
+      reportError(`Não foi possível atualizar o estágio: ${err.message}`);
+    }
+  }, [trackedJobs, reportError]);
 
-  const updateNotes = useCallback((id, notes) => {
+  const updateNotes = useCallback(async (id, notes) => {
+    const prevSnapshot = trackedJobs;
     setTrackedJobs((prev) => prev.map((j) => (j.id === id ? { ...j, notes } : j)));
-  }, []);
+    try {
+      const data = await fetchJSON(`/api/me/tracked/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ notes }),
+      });
+      const fresh = trackedToLocal(data.tracked);
+      setTrackedJobs((prev) => prev.map((j) => (j.id === fresh.id ? fresh : j)));
+    } catch (err) {
+      setTrackedJobs(prevSnapshot);
+      reportError(`Não foi possível salvar as anotações: ${err.message}`);
+    }
+  }, [trackedJobs, reportError]);
 
-  const removeJob = useCallback((id) => {
+  const removeJob = useCallback(async (id) => {
+    const prevSnapshot = trackedJobs;
     setTrackedJobs((prev) => prev.filter((j) => j.id !== id));
-  }, []);
+    try {
+      await fetchJSON(`/api/me/tracked/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    } catch (err) {
+      setTrackedJobs(prevSnapshot);
+      reportError(`Não foi possível remover: ${err.message}`);
+    }
+  }, [trackedJobs, reportError]);
 
-  const isTracked = useCallback((id) => trackedJobs.some((j) => j.id === id), [trackedJobs]);
+  const isTracked = useCallback((id) => trackedJobs.some((j) => j.id === String(id)), [trackedJobs]);
 
-  return { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked };
+  return { trackedJobs, addJob, updateStage, updateNotes, removeJob, isTracked, loaded };
 }

--- a/web/src/hooks/useTrackedJobs.js
+++ b/web/src/hooks/useTrackedJobs.js
@@ -52,7 +52,7 @@ export default function useTrackedJobs(authStatus, onError) {
     let cancelled = false;
     (async () => {
       try {
-        const data = await fetchJSON('/api/me/tracked');
+        const data = await fetchJSON('/me/tracked');
         if (cancelled) return;
         setTrackedJobs((data?.tracked || []).map(trackedToLocal));
         setLoaded(true);
@@ -75,7 +75,7 @@ export default function useTrackedJobs(authStatus, onError) {
     };
     setTrackedJobs((prev) => [...prev, optimistic]);
     try {
-      const data = await fetchJSON('/api/me/tracked', {
+      const data = await fetchJSON('/me/tracked', {
         method: 'POST',
         body: JSON.stringify(localToServer(job)),
       });
@@ -91,7 +91,7 @@ export default function useTrackedJobs(authStatus, onError) {
     const prevSnapshot = trackedJobs;
     setTrackedJobs((prev) => prev.map((j) => (j.id === id ? { ...j, stage } : j)));
     try {
-      const data = await fetchJSON(`/api/me/tracked/${encodeURIComponent(id)}`, {
+      const data = await fetchJSON(`/me/tracked/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         body: JSON.stringify({ stage }),
       });
@@ -107,7 +107,7 @@ export default function useTrackedJobs(authStatus, onError) {
     const prevSnapshot = trackedJobs;
     setTrackedJobs((prev) => prev.map((j) => (j.id === id ? { ...j, notes } : j)));
     try {
-      const data = await fetchJSON(`/api/me/tracked/${encodeURIComponent(id)}`, {
+      const data = await fetchJSON(`/me/tracked/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         body: JSON.stringify({ notes }),
       });
@@ -123,7 +123,7 @@ export default function useTrackedJobs(authStatus, onError) {
     const prevSnapshot = trackedJobs;
     setTrackedJobs((prev) => prev.filter((j) => j.id !== id));
     try {
-      await fetchJSON(`/api/me/tracked/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      await fetchJSON(`/me/tracked/${encodeURIComponent(id)}`, { method: 'DELETE' });
     } catch (err) {
       setTrackedJobs(prevSnapshot);
       reportError(`Não foi possível remover: ${err.message}`);

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -1,7 +1,7 @@
 .app { min-height: 100vh; display: grid; grid-template-columns: 240px 1fr; }
 
 .sidebar {
-  background: #fff;
+  background: var(--jh-surface);
   border-right: 1px solid var(--jh-border);
   padding: 1.5rem 1rem;
   display: flex;
@@ -34,14 +34,14 @@
   text-align: left;
   font-family: inherit;
 }
-.nav-item:hover { background: #f1f5f9; }
+.nav-item:hover { background: var(--jh-surface-2); }
 .nav-item.active { background: var(--jh-primary-50); color: var(--jh-primary); font-weight: 600; }
-.nav-item .nav-count { background: #f1f5f9; color: var(--jh-fg-muted); font-size: 0.6875rem; font-weight: 600; padding: 1px 8px; border-radius: 9999px; }
+.nav-item .nav-count { background: var(--jh-surface-2); color: var(--jh-fg-muted); font-size: 0.6875rem; font-weight: 600; padding: 1px 8px; border-radius: 9999px; }
 .nav-item.active .nav-count { background: #dbeafe; color: var(--jh-primary); }
 .sidebar-foot { margin-top: auto; padding-top: 0.75rem; border-top: 1px solid var(--jh-border); display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.75rem; color: var(--jh-fg-muted); }
 .sidebar-foot-user { display: flex; align-items: center; gap: 8px; padding: 0.4rem 0.5rem; width: 100%; background: none; border: 1px solid transparent; border-radius: 0.5rem; cursor: pointer; font: inherit; color: inherit; text-align: left; transition: background-color 0.15s, border-color 0.15s; }
-.sidebar-foot-user:hover { background: #f1f5f9; }
-.sidebar-foot-user.is-open { background: #f1f5f9; border-color: var(--jh-border); }
+.sidebar-foot-user:hover { background: var(--jh-surface-2); }
+.sidebar-foot-user.is-open { background: var(--jh-surface-2); border-color: var(--jh-border); }
 .sidebar-foot-user .avatar { width: 28px; height: 28px; border-radius: 50%; background: var(--jh-primary); color: #fff; font-weight: 700; font-size: 12px; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
 .sidebar-foot-user-text { min-width: 0; overflow: hidden; flex: 1 1 auto; }
 .sidebar-foot-user-text > div { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 0.75rem; }
@@ -56,18 +56,18 @@
 .btn { padding: 0.5rem 1rem; font-size: 0.8125rem; font-weight: 600; border-radius: 0.5rem; cursor: pointer; font-family: inherit; border: 1px solid transparent; transition: all 0.15s; display: inline-flex; align-items: center; gap: 6px; }
 .btn-primary { background: var(--jh-primary); color: #fff; }
 .btn-primary:hover { background: var(--jh-primary-hover); }
-.btn-ghost { background: #fff; color: var(--jh-fg); border-color: var(--jh-border); }
+.btn-ghost { background: var(--jh-surface); color: var(--jh-fg); border-color: var(--jh-border); }
 .btn-ghost:hover { border-color: var(--jh-primary); color: var(--jh-primary); }
 .btn-sm { padding: 0.3rem 0.625rem; font-size: 0.75rem; }
 .btn-block { width: 100%; justify-content: center; padding: 0.75rem 1rem; }
 .link-btn { background: none; border: none; color: var(--jh-primary); font: inherit; font-size: 0.75rem; font-weight: 600; cursor: pointer; padding: 0; }
 .link-btn:hover { text-decoration: underline; }
 
-.card { background: #fff; border: 1px solid var(--jh-border); border-radius: 0.75rem; box-shadow: var(--jh-shadow-sm); }
+.card { background: var(--jh-surface); border: 1px solid var(--jh-border); border-radius: 0.75rem; box-shadow: var(--jh-shadow-sm); }
 .card-pad { padding: 1.25rem; }
 
 .stat-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1.5rem; }
-.stat { background: #fff; border: 1px solid var(--jh-border); border-radius: 0.75rem; padding: 1.25rem; }
+.stat { background: var(--jh-surface); border: 1px solid var(--jh-border); border-radius: 0.75rem; padding: 1.25rem; }
 .stat-label { font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--jh-fg-muted); }
 .stat-value { font-size: 1.75rem; font-weight: 800; letter-spacing: -0.025em; color: var(--jh-fg); margin-top: 0.25rem; }
 .stat-delta { font-size: 0.75rem; color: var(--jh-success); font-weight: 600; margin-top: 0.25rem; }
@@ -78,41 +78,41 @@
 .list-row .meta { font-size: 0.75rem; color: var(--jh-fg-muted); margin-top: 2px; }
 
 .kanban { display: grid; grid-template-columns: repeat(5, minmax(240px, 1fr)); gap: 1rem; align-items: start; }
-.kanban-col { background: #f1f5f9; border: 1px solid var(--jh-border); border-radius: 0.75rem; padding: 0.75rem; min-height: 260px; }
+.kanban-col { background: var(--jh-surface-2); border: 1px solid var(--jh-border); border-radius: 0.75rem; padding: 0.75rem; min-height: 260px; }
 .kanban-col-head { display: flex; justify-content: space-between; align-items: center; padding: 0 0.25rem 0.625rem; }
 .kanban-col-head .name { font-size: 0.8125rem; font-weight: 700; color: var(--jh-fg); display: flex; align-items: center; gap: 6px; }
 .kanban-col-head .dot { width: 8px; height: 8px; border-radius: 50%; }
 .kanban-col-head .count { font-size: 0.75rem; color: var(--jh-fg-muted); font-weight: 600; }
-.kanban-card { background: #fff; border: 1px solid var(--jh-border); border-radius: 0.5rem; padding: 0.75rem; box-shadow: var(--jh-shadow-sm); margin-bottom: 0.5rem; cursor: grab; }
+.kanban-card { background: var(--jh-surface); border: 1px solid var(--jh-border); border-radius: 0.5rem; padding: 0.75rem; box-shadow: var(--jh-shadow-sm); margin-bottom: 0.5rem; cursor: grab; }
 .kanban-card:hover { border-color: #cbd5e1; box-shadow: var(--jh-shadow); }
 .kanban-card .title { font-size: 0.8125rem; font-weight: 600; color: var(--jh-fg); line-height: 1.35; }
 .kanban-card .company { font-size: 0.75rem; color: var(--jh-fg-muted); margin-top: 2px; }
 .kanban-card .footer { display: flex; justify-content: space-between; align-items: center; margin-top: 0.625rem; }
 .kanban-card .ago { font-size: 0.6875rem; color: var(--jh-fg-subtle); }
-.kanban-card-move { margin-top: 0.5rem; width: 100%; font-size: 0.6875rem; padding: 0.2rem 0.3rem; border: 1px solid var(--jh-border); border-radius: 0.375rem; background: #fff; color: var(--jh-fg-muted); font-family: inherit; }
+.kanban-card-move { margin-top: 0.5rem; width: 100%; font-size: 0.6875rem; padding: 0.2rem 0.3rem; border: 1px solid var(--jh-border); border-radius: 0.375rem; background: var(--jh-surface); color: var(--jh-fg-muted); font-family: inherit; }
 
 .saved-row { display: grid; grid-template-columns: 1fr auto auto; gap: 1rem; align-items: center; padding: 1rem 1.25rem; border-bottom: 1px solid var(--jh-border); transition: background-color 0.15s; }
-.saved-row:hover { background: #f8fafc; }
+.saved-row:hover { background: var(--jh-surface-2); }
 .saved-row:last-child { border-bottom: none; }
 .saved-row .title { font-weight: 600; color: var(--jh-fg); }
 .saved-row .meta { font-size: 0.75rem; color: var(--jh-fg-muted); margin-top: 4px; display: flex; gap: 0.5rem; align-items: center; }
-.icon-btn { width: 32px; height: 32px; border: 1px solid var(--jh-border); border-radius: 0.5rem; background: #fff; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; color: var(--jh-fg-muted); padding: 0; }
+.icon-btn { width: 32px; height: 32px; border: 1px solid var(--jh-border); border-radius: 0.5rem; background: var(--jh-surface); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; color: var(--jh-fg-muted); padding: 0; }
 .icon-btn:hover { border-color: var(--jh-primary); color: var(--jh-primary); }
 .icon-btn.is-saved { color: var(--jh-danger); border-color: var(--jh-danger); }
 
 .detail-grid-tracker { display: grid; grid-template-columns: 1.6fr 1fr; gap: 1.5rem; align-items: start; }
 .timeline { padding-left: 0.75rem; border-left: 2px solid var(--jh-border); margin-top: 0.5rem; }
 .timeline-item { position: relative; padding: 0.625rem 0 0.625rem 1rem; }
-.timeline-item::before { content: ''; position: absolute; left: -0.93rem; top: 1rem; width: 10px; height: 10px; border-radius: 50%; background: var(--jh-primary); border: 2px solid #fff; box-shadow: 0 0 0 1px var(--jh-border); }
+.timeline-item::before { content: ''; position: absolute; left: -0.93rem; top: 1rem; width: 10px; height: 10px; border-radius: 50%; background: var(--jh-primary); border: 2px solid var(--jh-surface); box-shadow: 0 0 0 1px var(--jh-border); }
 .timeline-item.muted::before { background: #cbd5e1; }
 .timeline-item .when { font-size: 0.6875rem; font-weight: 600; color: var(--jh-fg-muted); text-transform: uppercase; letter-spacing: 0.04em; }
 .timeline-item .what { font-size: 0.8125rem; color: var(--jh-fg); margin-top: 2px; }
-textarea.notes { width: 100%; min-height: 96px; padding: 0.75rem; border: 1px solid var(--jh-border); border-radius: 0.5rem; font: 400 0.8125rem var(--jh-font-sans); resize: vertical; color: var(--jh-fg); background: #fff; }
+textarea.notes { width: 100%; min-height: 96px; padding: 0.75rem; border: 1px solid var(--jh-border); border-radius: 0.5rem; font: 400 0.8125rem var(--jh-font-sans); resize: vertical; color: var(--jh-fg); background: var(--jh-surface); }
 textarea.notes:focus { outline: none; border-color: var(--jh-primary); box-shadow: 0 0 0 4px var(--jh-primary-ring); }
 
 .stage { font-size: 0.6875rem; font-weight: 700; padding: 0.25rem 0.625rem; border-radius: 9999px; text-transform: uppercase; letter-spacing: 0.04em; display: inline-flex; align-items: center; gap: 6px; }
 .stage::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
-.stage-salva   { background: #f1f5f9; color: #475569; }
+.stage-salva   { background: var(--jh-surface-2); color: #475569; }
 .stage-aplicada{ background: #dbeafe; color: #1e40af; }
 .stage-entrev  { background: #fef3c7; color: #92400e; }
 .stage-prop    { background: #d1fae5; color: #065f46; }
@@ -122,7 +122,7 @@ textarea.notes:focus { outline: none; border-color: var(--jh-primary); box-shado
 .empty-shell .big { font-size: 1rem; font-weight: 600; color: var(--jh-fg); margin-bottom: 0.25rem; }
 
 .login-shell { min-height: 100vh; display: grid; place-items: center; padding: 2rem; }
-.login-card { width: 100%; max-width: 400px; background: #fff; border: 1px solid var(--jh-border); border-radius: 1rem; padding: 2.5rem; box-shadow: var(--jh-shadow); }
+.login-card { width: 100%; max-width: 400px; background: var(--jh-surface); border: 1px solid var(--jh-border); border-radius: 1rem; padding: 2.5rem; box-shadow: var(--jh-shadow); }
 .login-card h2 { margin: 0 0 0.25rem; font-weight: 800; letter-spacing: -0.025em; font-size: 1.5rem; }
 .login-card p.lede { margin: 0 0 1.5rem; color: var(--jh-fg-muted); font-size: 0.875rem; }
 .field { display: flex; flex-direction: column; gap: 0.375rem; margin-bottom: 1rem; }
@@ -131,13 +131,13 @@ textarea.notes:focus { outline: none; border-color: var(--jh-primary); box-shado
 .field input:focus { outline: none; border-color: var(--jh-primary); box-shadow: 0 0 0 4px var(--jh-primary-ring); }
 
 .toast-tray { position: fixed; right: 1.5rem; bottom: 1.5rem; display: flex; flex-direction: column; gap: 0.5rem; z-index: 200; max-width: 360px; }
-.toast { display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.75rem 1rem; border-radius: 0.625rem; box-shadow: var(--jh-shadow); font-size: 0.8125rem; background: #fff; border: 1px solid var(--jh-border); color: var(--jh-fg); }
+.toast { display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.75rem 1rem; border-radius: 0.625rem; box-shadow: var(--jh-shadow); font-size: 0.8125rem; background: var(--jh-surface); border: 1px solid var(--jh-border); color: var(--jh-fg); }
 .toast-error { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
 .toast-info { background: var(--jh-primary-50); border-color: #bfdbfe; color: #1e40af; }
 .toast-close { background: none; border: none; color: inherit; font-size: 1rem; cursor: pointer; line-height: 1; padding: 0; flex: 0 0 auto; }
 
 .tracker-modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,0.7); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; padding: 1.5rem; z-index: 100; }
-.tracker-modal { background: #fff; border-radius: 1rem; max-width: 780px; width: 100%; max-height: 90vh; overflow: auto; box-shadow: var(--jh-shadow-modal); }
+.tracker-modal { background: var(--jh-surface); border-radius: 1rem; max-width: 780px; width: 100%; max-height: 90vh; overflow: auto; box-shadow: var(--jh-shadow-modal); }
 .tracker-modal-head { padding: 2rem 2rem 1rem; border-bottom: 1px solid var(--jh-border); display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; }
 .tracker-modal-title { margin: 0.5rem 0 0.25rem; font-size: 1.375rem; font-weight: 700; letter-spacing: -0.025em; }
 .tracker-modal-sub { color: var(--jh-fg-muted); font-size: 0.875rem; }

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -46,7 +46,13 @@
 .sidebar-foot-user-text { min-width: 0; overflow: hidden; flex: 1 1 auto; }
 .sidebar-foot-user-text > div { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 0.75rem; }
 .sidebar-foot-caret { color: var(--jh-fg-subtle); font-size: 0.75rem; flex: 0 0 auto; }
-.sidebar-foot-actions { display: flex; flex-direction: column; gap: 0.25rem; padding-top: 0.25rem; border-top: 1px dashed var(--jh-border); }
+.sidebar-foot-actions { display: flex; flex-direction: column; gap: 0.25rem; padding-bottom: 0.25rem; margin-bottom: 0.25rem; border-bottom: 1px dashed var(--jh-border); }
+.theme-switch { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; padding: 0.5rem 0.625rem; border-radius: 0.5rem; font-size: 0.875rem; font-weight: 500; }
+.theme-switch-label { display: inline-flex; align-items: center; gap: 8px; color: var(--jh-fg); }
+.theme-switch-toggle { width: 38px; height: 22px; border-radius: 999px; border: none; background: var(--jh-border); cursor: pointer; position: relative; padding: 0; flex: 0 0 auto; transition: background-color 0.15s; }
+.theme-switch-toggle.is-on { background: var(--jh-primary); }
+.theme-switch-knob { position: absolute; left: 2px; top: 2px; width: 18px; height: 18px; border-radius: 50%; background: var(--jh-surface); box-shadow: var(--jh-shadow-sm); transition: transform 0.15s; }
+.theme-switch-toggle.is-on .theme-switch-knob { transform: translateX(16px); }
 
 .main { padding: 2rem 2.5rem; }
 .page-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; gap: 1rem; }

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -130,6 +130,12 @@ textarea.notes:focus { outline: none; border-color: var(--jh-primary); box-shado
 .field input { padding: 0.625rem 0.875rem; border: 2px solid var(--jh-border); border-radius: 0.5rem; font: 400 0.875rem var(--jh-font-sans); }
 .field input:focus { outline: none; border-color: var(--jh-primary); box-shadow: 0 0 0 4px var(--jh-primary-ring); }
 
+.toast-tray { position: fixed; right: 1.5rem; bottom: 1.5rem; display: flex; flex-direction: column; gap: 0.5rem; z-index: 200; max-width: 360px; }
+.toast { display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.75rem 1rem; border-radius: 0.625rem; box-shadow: var(--jh-shadow); font-size: 0.8125rem; background: #fff; border: 1px solid var(--jh-border); color: var(--jh-fg); }
+.toast-error { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
+.toast-info { background: var(--jh-primary-50); border-color: #bfdbfe; color: #1e40af; }
+.toast-close { background: none; border: none; color: inherit; font-size: 1rem; cursor: pointer; line-height: 1; padding: 0; flex: 0 0 auto; }
+
 .tracker-modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,0.7); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; padding: 1.5rem; z-index: 100; }
 .tracker-modal { background: #fff; border-radius: 1rem; max-width: 780px; width: 100%; max-height: 90vh; overflow: auto; box-shadow: var(--jh-shadow-modal); }
 .tracker-modal-head { padding: 2rem 2rem 1rem; border-bottom: 1px solid var(--jh-border); display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -5,6 +5,8 @@
   --jh-primary-ring: rgba(37, 99, 235, 0.15);
 
   --jh-bg: #f8fafc;
+  --jh-surface: #ffffff;
+  --jh-surface-2: #f1f5f9;
   --jh-fg: #1e293b;
   --jh-fg-strong: #0f172a;
   --jh-fg-muted: #64748b;
@@ -26,7 +28,7 @@
   --primary-hover: var(--jh-primary-hover);
   --secondary: var(--jh-fg-muted);
   --bg-color: var(--jh-bg);
-  --card-bg: #ffffff;
+  --card-bg: var(--jh-surface);
   --text-main: var(--jh-fg);
   --text-muted: var(--jh-fg-muted);
   --border-color: var(--jh-border);
@@ -35,6 +37,26 @@
   --shadow-sm: var(--jh-shadow-sm);
   --shadow: var(--jh-shadow);
   --radius: var(--jh-radius);
+}
+
+:root[data-theme="dark"] {
+  --jh-primary: #3b82f6;
+  --jh-primary-hover: #60a5fa;
+  --jh-primary-50: #1e3a8a;
+  --jh-primary-ring: rgba(59, 130, 246, 0.35);
+
+  --jh-bg: #0f172a;
+  --jh-surface: #1e293b;
+  --jh-surface-2: #111827;
+  --jh-fg: #e2e8f0;
+  --jh-fg-strong: #f8fafc;
+  --jh-fg-muted: #94a3b8;
+  --jh-fg-subtle: #64748b;
+  --jh-border: #334155;
+
+  --jh-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.5);
+  --jh-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.6), 0 2px 4px -2px rgb(0 0 0 / 0.5);
+  --jh-shadow-modal: 0 25px 50px -12px rgb(0 0 0 / 0.7);
 }
 
 * { box-sizing: border-box; }

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -1,0 +1,35 @@
+export const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+
+export class ApiError extends Error {
+  constructor(message, { status, body } = {}) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export async function fetchJSON(path, opts = {}) {
+  const { signal, headers, ...rest } = opts;
+  const res = await fetch(`${API_URL}${path}`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...(headers || {}),
+    },
+    signal,
+    ...rest,
+  });
+  if (res.status === 204) return null;
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  if (!res.ok) {
+    const message = (body && body.error) || `HTTP ${res.status}`;
+    throw new ApiError(message, { status: res.status, body });
+  }
+  return body;
+}

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -1,4 +1,4 @@
-export const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+export const API_URL = process.env.REACT_APP_API_URL || '/api';
 
 export class ApiError extends Error {
   constructor(message, { status, body } = {}) {


### PR DESCRIPTION
## Summary

Implements TASKS.md from PR #54. Four epics, one commit per story (~14 commits).

### Epic 1 — Auth backend (Flask + SQLite)
- `users` table + `_ensure_app_schema` migration mirroring the existing `_DETAIL_MIGRATIONS` pattern.
- `api/auth.py` with `hash_password` / `verify_password` / `is_valid_password` (werkzeug, no new dep), `current_user_id`, and `@login_required`.
- `POST /api/auth/register` (409 on dup), `POST /api/auth/login` (generic 401), `POST /api/auth/logout` (204), `GET /api/auth/me`.
- Cookie session via `flask.session`: `HttpOnly`, `SameSite=Lax`, `Secure` toggleable via `SESSION_COOKIE_SECURE`. `permanent_session_lifetime = 30d`. `SECRET_KEY` from env (raises in `FLASK_ENV=production` if missing).

### Epic 2 — Auth frontend
- `web/src/utils/api.js` — `fetchJSON` with `credentials: 'include'` and `ApiError`.
- `web/src/hooks/useAuth.js` — `{user, status, login, register, logout, refresh}` with `status ∈ {loading, anonymous, authenticated}`.
- `Login.jsx` rebuilt as a real form with login/register toggle, surfacing API error bodies inline.
- `App.js` gates on `auth.status === 'authenticated'` instead of `localStorage.jh_authed`. Logout calls `useAuth().logout()`.

### Epic 3 — Tracker persisted per user
- `tracked_jobs` table (PK `(user_id, job_id)`, FK `user_id → users(id) ON DELETE CASCADE`, `events TEXT` JSON, `stage`, `notes`, timestamps).
- `GET/POST/PATCH/DELETE /api/me/tracked` with `STAGE_ORDER` server-side validation; PATCH stage appends a timeline event.
- `useTrackedJobs(authStatus, onError)` rewritten as API-backed with optimistic updates and rollback on error. Same hook shape as before — kit pages untouched.
- Per-user isolation verified end-to-end (smoke test in PR conversation).
- Tiny toast tray (`useToasts` + `ToastTray`) for tracker-error surfacing; replaces the inline error banner.
- Settings page reduced to a read-only username + "em breve" copy (the old name/email form was localStorage-only and misleading).

### Epic 4 — Dark theme toggle in user menu
- `tokens.css` adds `:root[data-theme="dark"] { ... }` overrides plus `--jh-surface` / `--jh-surface-2` semantic tokens. Existing `--primary` etc. continue to alias.
- `App.css` and `shell.css` swept to replace hardcoded `#fff` / `#f1f5f9` / `#f8fafc` / `white` with the new vars (~10 selectors).
- `useTheme` — `system | light | dark` cycler, persisted in `jh_theme`, watches `prefers-color-scheme` for `system`.
- `Sidebar` foot menu: a third action between Configurações and Sair cycles the theme; icon + label reflect the current value.

### Decisions kept from TASKS.md
- No `react-router-dom`, no Flask-Login, no JWT.
- No `STAGE_ORDER` shared module — Python and JS each carry their own (kept manually in sync).
- No migration of legacy `localStorage.jh_jobs` (per decision D).

## Test plan

- [ ] `docker compose build api web` (passes; `auth.py` is included via the API Dockerfile).
- [ ] `docker compose up -d` with `SECRET_KEY` set in `.env`.
- [ ] Register two users; verify cross-user isolation of `/api/me/tracked`.
- [ ] Save / advance stage / add notes / remove via the SPA — all persist after a refresh and after a logout/login cycle.
- [ ] Toggle theme; reload — persists. Set OS to dark with `theme=system` — SPA flips automatically.
- [ ] Logout from the user menu returns to Login screen.
- [ ] Unauthenticated `curl /api/me/tracked` returns 401; `curl /api/jobs` still works (public).

## Follow-ups (out of scope)

- Change-password endpoint + UI.
- Migration of legacy `localStorage.jh_jobs`.
- Visual polish pass over kanban / JobDetails in dark mode (Story 4.4 — covered by the surface-token sweep, screenshots pending in browser walkthrough).